### PR TITLE
#29-update-eslint-rule-jsx-no-spreading

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,9 @@
       }
     ],
     "react/react-in-jsx-scope": "off",
-    "react/jsx-props-no-spreading": "off",
+    "react/jsx-props-no-spreading": ["error", {
+      "custom": "ignore"
+    }],
     "no-use-before-define": [
       "error",
       {

--- a/src/components/templates/card/card.jsx
+++ b/src/components/templates/card/card.jsx
@@ -1,13 +1,12 @@
 import PropTypes from 'prop-types';
 import styles from './card.module.scss';
 
-function Card({ className, children, nopadding, ...props }) {
+function Card({ className, children, nopadding }) {
   return (
     <div
       className={`${styles.card}${nopadding ? ` ${styles.cardNoPadding}` : ''}${
         className.length > 0 ? ` ${className}` : ''
       }`}
-      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
Обновление правила для `react/jsx-props-no-spreading`, запрет за использование spread в jsx-элементах.

Кейс:
```
const Button = props => {
  return <button className='button' {...props} />;
};
```

1) Это опасно, так как можно отправить в DOM невалидные атрибуты. Об этом даже есть сноска в доке:

> Spread attributes can be useful but they also make it easy to pass unnecessary props to components that don’t care about them or to pass invalid HTML attributes to the DOM. We recommend using this syntax sparingly.

2) При подобном спрединге API компонента становится непрозрачным, а входящие параметры не типизируются и не проверяются. Нарушается изолированность компонента, и не покрыть все кейсы при тестировании. Плохая практика для продакшена, так как пользователь должен получить 1000% рабочий и проверенный код.

Что правило не затрагивает:
```
const App = () => {
  const data = {...}
  return (
      <Component {...data} />
  );
};
```

Также его можно использовать в HOC-компонентах. Запрет только на jsx-элементы, которые непосредственно уходят в DOM.