### PR TITLE
Bug-#376-course-main-section-layout

### DIFF
--- a/src/pages/course/course.module.scss
+++ b/src/pages/course/course.module.scss
@@ -15,6 +15,7 @@
   display: flex;
   flex-direction: column;
   row-gap: vars.$grid-gap;
+  width: 100%;
   max-width: 872px;
 }
 


### PR DESCRIPTION
## Связанная задача: [#376 Починить верстку карточки на странице курса](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/376)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

В компоненте Course поправлена ширина div 'main' - была ошибка, что при небольшом содержимом карточка на странице курса сжималась.