### PR TITLE
Enhancement-#389-course-content

### DIFF
--- a/src/components/molecules/styled-link/styled-link.module.scss
+++ b/src/components/molecules/styled-link/styled-link.module.scss
@@ -5,12 +5,6 @@
   font-family: vars.$mainFont;
   font-size: vars.$font-size-m;
   line-height: vars.$line-height-m;
-  color: vars.$dark-primary;
-  transition: color vars.$trans-300;
-
-  &:hover {
-    color: vars.$color-hover;
-  }
 }
 
 .normal {
@@ -23,6 +17,15 @@
 
 .medium {
   font-weight: 500;
+}
+
+.default {
+  color: vars.$dark-primary;
+  transition: color vars.$trans-300;
+
+  &:hover {
+    color: vars.$color-hover;
+  }
 }
 
 .active {

--- a/src/components/molecules/styled-link/styled-link.tsx
+++ b/src/components/molecules/styled-link/styled-link.tsx
@@ -16,14 +16,20 @@ export const StyledLink: FC<StyledLinkProps> = ({
   isNavigation,
   href,
   weight = 'medium',
-  className = '',
+  color = 'default',
+  className,
   ...props
 }) => {
   if (!children && !linkText) {
     return null;
   }
 
-  const classNames = classnames(styles.link, styles[weight], styles[className]);
+  const classNames = classnames(
+    styles.link,
+    styles[weight],
+    styles[color],
+    className
+  );
 
   if (isExternal) {
     return (
@@ -44,7 +50,7 @@ export const StyledLink: FC<StyledLinkProps> = ({
       <NavLink
         {...props}
         className={({ isActive }) =>
-          isActive ? ` ${classNames} ${styles.active}` : classNames
+          classnames(classNames, { [styles.active]: isActive })
         }
         to={href}
         end

--- a/src/components/molecules/styled-link/types.ts
+++ b/src/components/molecules/styled-link/types.ts
@@ -15,11 +15,13 @@ export type StyledLinkProps = {
   isExternal?: boolean;
   /**
    * Флаг того, является ли ссылка навигационной. При true используется ссылка NavLink из react-router.
-   * * По умолчанию используется ссылка Link из react-router.
+   * По умолчанию используется ссылка Link из react-router.
    * */
   isNavigation?: boolean;
   /** Начертание шрифта. */
   weight?: 'bold' | 'medium' | 'normal';
+  /** Цвет текста. */
+  color?: 'default' | 'active';
   /** Миксин для стилизации. Используйте css-класс, чтобы изменить css-свойства элемента. */
   className?: string;
 } & AnchorHTMLAttributes<HTMLAnchorElement>;

--- a/src/components/organisms/contents-item/contents-item.tsx
+++ b/src/components/organisms/contents-item/contents-item.tsx
@@ -8,6 +8,7 @@ import { P } from 'components/atoms/typography';
 import { Accordion } from 'components/molecules/accordion';
 import { StyledLink } from 'components/molecules/styled-link';
 import { TextWithIcon } from 'components/molecules/text-with-icon';
+import { LessonProgress } from 'api/course/types';
 import styles from './contents-item.module.scss';
 import type { ContentsItemProps, LessonType } from './types';
 
@@ -24,9 +25,9 @@ function renderLesson(
   courseId: string,
   chapterId: number
 ) {
-  const currentLessonRoute = `../${routes.course.path}/${courseId}/${chapterId}/${lesson.id}`;
+  const currentLessonRoute = `${routes.course.path}/${courseId}/${chapterId}/${lesson.id}`;
 
-  if (lesson.lesson_progress === '2') {
+  if (lesson.lesson_progress === LessonProgress.Finished) {
     return (
       <div
         className={classnames(styles.listItem, {
@@ -50,7 +51,7 @@ function renderLesson(
     );
   }
 
-  if (lesson.lesson_progress === '1') {
+  if (lesson.lesson_progress === LessonProgress.Started) {
     return (
       <div
         className={classnames(styles.listItem, styles.active)}
@@ -60,7 +61,7 @@ function renderLesson(
           href={currentLessonRoute}
           isNavigation
           weight="normal"
-          className="active"
+          color="active"
         >
           <TextWithIcon
             text={lesson.title}


### PR DESCRIPTION
## Связанная задача: [#389 Доработать содержание курса (настроить роутинг, проверить отображение статусов уроков для страницы урока)](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/389)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:
- Настроен роутинг содержания для страницы курса и страницы урока (все пройденные уроки и последний непройденный урок успешно открываются при нажатии на тему урока).
- Последний непройденный урок выделен оранжевым и на странице курса, не только на странице урока (дополнение от меня, при необходимости уберу)
- Настроена стилизация для выбранного (активного) урока, для этого немного поправила компонент StyledLink (добавила NavLink) (дополнение от меня, при необходимости уберу)

### Комментарий:
Нет возможности проверить корректность работы содержания на данных с бэка, так как там пока все уроки со статусом "не начат".