### PR TITLE
Development-#352-YandexOAuthButton-Component

### DIFF
--- a/src/components/molecules/button/button.module.scss
+++ b/src/components/molecules/button/button.module.scss
@@ -65,14 +65,6 @@
   }
 }
 
-.view-tertiary {
-  background-color: vars.$dark-primary;
-  color: vars.$bg-primary;
-  font-family: vars.$yandexFont;
-  min-width: 72px;
-  min-height: 48px;
-}
-
 .view-text {
   color: vars.$dark-primary;
   padding: 0;

--- a/src/components/molecules/button/types.ts
+++ b/src/components/molecules/button/types.ts
@@ -1,7 +1,7 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import type { IconSize, IconType } from 'components/atoms/icon';
 
-export type ButtonView = 'primary' | 'secondary' | 'tertiary' | 'text';
+export type ButtonView = 'primary' | 'secondary' | 'text';
 export type ButtonHover = 'default' | 'border';
 
 export type ButtonProps = {

--- a/src/components/molecules/yandex-oauth-button/index.ts
+++ b/src/components/molecules/yandex-oauth-button/index.ts
@@ -1,0 +1,2 @@
+export { YandexOAuthButton } from './yandex-oauth-button';
+export type { YandexOAuthButtonProps } from './types';

--- a/src/components/molecules/yandex-oauth-button/types.ts
+++ b/src/components/molecules/yandex-oauth-button/types.ts
@@ -1,0 +1,11 @@
+import type { ButtonHTMLAttributes } from 'react';
+import type { IconSize } from 'components/atoms/icon';
+
+export type YandexOAuthButtonProps = {
+  /** Текст кнопки. */
+  text?: string;
+  /** Миксин для стилизации, присваивается элементу button. Используйте css-класс, чтобы изменить css-свойства элемента. */
+  className?: string;
+  /** Размер иконки. */
+  iconSize?: IconSize;
+} & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/components/molecules/yandex-oauth-button/types.ts
+++ b/src/components/molecules/yandex-oauth-button/types.ts
@@ -1,11 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
-import type { IconSize } from 'components/atoms/icon';
 
 export type YandexOAuthButtonProps = {
-  /** Текст кнопки. */
-  text?: string;
   /** Миксин для стилизации, присваивается элементу button. Используйте css-класс, чтобы изменить css-свойства элемента. */
   className?: string;
-  /** Размер иконки. */
-  iconSize?: IconSize;
 } & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
+++ b/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
@@ -1,17 +1,15 @@
 @use 'src/styles/variables' as vars;
 
 .button {
-  min-width: 228px;
-  min-height: 44px;
-  width: 236px;
+  width: 100%;
   height: 48px;
-  padding: 0 28px;
+  padding: 0 24px;
   box-sizing: border-box;
   background-color: vars.$bg-yandex;
   border: none;
   border-radius: vars.$border-radius;
   cursor: pointer;
-  color: vars.$bg-primary;
+  color: vars.$yandex-text-color;
   font-family: vars.$yandexFont;
   font-size: vars.$font-size-s;
   font-style: normal;
@@ -21,14 +19,9 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  transition: vars.$trans-300;
 
   &:focus {
     outline: none;
-  }
-
-  &:disabled {
-    box-shadow: none;
   }
 }
 

--- a/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
+++ b/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
@@ -1,25 +1,26 @@
 @use 'src/styles/variables' as vars;
 
 .button {
-  min-width: 72px;
-  min-height: 48px;
+  min-width: 228px;
+  min-height: 44px;
+  width: 236px;
+  height: 48px;
+  padding: 0 28px;
   box-sizing: border-box;
-  padding: 0 24px;
-  background: transparent;
-  background-color: vars.$dark-primary;
+  background-color: vars.$bg-yandex;
   border: none;
   border-radius: vars.$border-radius;
   cursor: pointer;
   color: vars.$bg-primary;
   font-family: vars.$yandexFont;
-  font-size: vars.$font-size-m;
+  font-size: vars.$font-size-s;
   font-style: normal;
   font-weight: 500;
-  line-height: vars.$line-height-m;
+  line-height: vars.$line-height-s;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 12px;
   transition: vars.$trans-300;
 
   &:focus {

--- a/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
+++ b/src/components/molecules/yandex-oauth-button/yandex-oauth-button.module.scss
@@ -1,0 +1,37 @@
+@use 'src/styles/variables' as vars;
+
+.button {
+  min-width: 72px;
+  min-height: 48px;
+  box-sizing: border-box;
+  padding: 0 24px;
+  background: transparent;
+  background-color: vars.$dark-primary;
+  border: none;
+  border-radius: vars.$border-radius;
+  cursor: pointer;
+  color: vars.$bg-primary;
+  font-family: vars.$yandexFont;
+  font-size: vars.$font-size-m;
+  font-style: normal;
+  font-weight: 500;
+  line-height: vars.$line-height-m;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: vars.$trans-300;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:disabled {
+    box-shadow: none;
+  }
+}
+
+.icon {
+  background-color: vars.$bg-yandex-logo;
+  border-radius: 50%;
+}

--- a/src/components/molecules/yandex-oauth-button/yandex-oauth-button.tsx
+++ b/src/components/molecules/yandex-oauth-button/yandex-oauth-button.tsx
@@ -1,0 +1,25 @@
+import type { FC } from 'react';
+import classnames from 'classnames';
+import { Icon } from 'components/atoms/icon';
+import styles from './yandex-oauth-button.module.scss';
+import type { YandexOAuthButtonProps } from './types';
+
+/**
+ * Компонент кнопки авторизации через Яндекс ID с иконкой-логотипом Яндекса.
+ * Содержит собственную разметку, т.к. дизайн кнопки строго регламентирован Яндексом и не зависит от остальных кнопок проекта.
+ */
+
+export const YandexOAuthButton: FC<YandexOAuthButtonProps> = ({
+  text = 'Войти c Яндекс ID',
+  className,
+  iconSize = 'medium',
+  ...props
+}) => {
+  const btnClasses = classnames(styles.button, className);
+  return (
+    <button {...props} className={btnClasses} type="button">
+      <Icon type="yandex" size={iconSize} className={styles.icon} />
+      {text}
+    </button>
+  );
+};

--- a/src/components/molecules/yandex-oauth-button/yandex-oauth-button.tsx
+++ b/src/components/molecules/yandex-oauth-button/yandex-oauth-button.tsx
@@ -7,19 +7,19 @@ import type { YandexOAuthButtonProps } from './types';
 /**
  * Компонент кнопки авторизации через Яндекс ID с иконкой-логотипом Яндекса.
  * Содержит собственную разметку, т.к. дизайн кнопки строго регламентирован Яндексом и не зависит от остальных кнопок проекта.
+ * Документация оформления кнопки: https://yandex.ru/dev/id/doc/ru/codes/buttons-design
  */
 
 export const YandexOAuthButton: FC<YandexOAuthButtonProps> = ({
-  text = 'Войти c Яндекс ID',
   className,
-  iconSize = 'medium',
   ...props
-}) => {
-  const btnClasses = classnames(styles.button, className);
-  return (
-    <button {...props} className={btnClasses} type="button">
-      <Icon type="yandex" size={iconSize} className={styles.icon} />
-      {text}
-    </button>
-  );
-};
+}) => (
+  <button
+    {...props}
+    className={classnames(styles.button, className)}
+    type="button"
+  >
+    <Icon type="yandex" className={styles.icon} />
+    Войти c Яндекс ID
+  </button>
+);

--- a/src/components/organisms/login-form/login-form.module.scss
+++ b/src/components/organisms/login-form/login-form.module.scss
@@ -30,9 +30,12 @@
 }
 
 .button {
-  margin: 0 auto;
   width: 236px;
   padding: 0 22px;
+
+  &_margin {
+    margin: 0 auto;
+  }
 }
 
 .registerLink {

--- a/src/components/organisms/login-form/login-form.module.scss
+++ b/src/components/organisms/login-form/login-form.module.scss
@@ -35,11 +35,6 @@
   padding: 0 22px;
 }
 
-.icon {
-  background-color: vars.$bg-yandex-logo;
-  border-radius: 50%;
-}
-
 .registerLink {
   color: vars.$dark-secondary;
   margin: 24px auto 0;

--- a/src/components/organisms/login-form/login-form.module.scss
+++ b/src/components/organisms/login-form/login-form.module.scss
@@ -29,13 +29,13 @@
   color: vars.$dark-secondary;
 }
 
+.submitButton {
+  padding: 0 24px;
+}
+
 .button {
   width: 236px;
-  padding: 0 22px;
-
-  &_margin {
-    margin: 0 auto;
-  }
+  margin: 0 auto;
 }
 
 .registerLink {

--- a/src/components/organisms/login-form/login-form.tsx
+++ b/src/components/organisms/login-form/login-form.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
 import { Button } from 'components/molecules/button';
+import { YandexOAuthButton } from 'components/molecules/yandex-oauth-button/yandex-oauth-button';
 import { Checkbox } from 'components/molecules/checkbox';
 import { Input } from 'components/molecules/input';
 import { StyledLink } from 'components/molecules/styled-link';
@@ -121,15 +122,7 @@ export const LoginForm: FC = () => {
         />
       </form>
 
-      {/* TODO: вынести в компонент YandexOAuthButton */}
-      <Button
-        className={classnames(styles.button)}
-        classNameIcon={styles.icon}
-        view="tertiary"
-        iconName="yandex"
-        iconSize="medium"
-        text="Войти c Яндекс ID"
-      />
+      <YandexOAuthButton className={classnames(styles.button)} />
 
       <StyledLink
         href={routes.register.path}

--- a/src/components/organisms/login-form/login-form.tsx
+++ b/src/components/organisms/login-form/login-form.tsx
@@ -115,14 +115,14 @@ export const LoginForm: FC = () => {
         </div>
 
         <Button
-          className={classnames(styles.button, styles.button_margin)}
+          className={classnames(styles.button, styles.submitButton)}
           type="submit"
           disabled={areAllValuesSet && (formik.isSubmitting || !formik.isValid)}
           text={isAuthLoading ? 'Вход...' : 'Войти'}
         />
       </form>
 
-      <YandexOAuthButton className={styles.button_margin} />
+      <YandexOAuthButton className={styles.button} />
 
       <StyledLink
         href={routes.register.path}

--- a/src/components/organisms/login-form/login-form.tsx
+++ b/src/components/organisms/login-form/login-form.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
 import { Button } from 'components/molecules/button';
-import { YandexOAuthButton } from 'components/molecules/yandex-oauth-button/yandex-oauth-button';
+import { YandexOAuthButton } from 'components/molecules/yandex-oauth-button';
 import { Checkbox } from 'components/molecules/checkbox';
 import { Input } from 'components/molecules/input';
 import { StyledLink } from 'components/molecules/styled-link';
@@ -115,14 +115,14 @@ export const LoginForm: FC = () => {
         </div>
 
         <Button
-          className={styles.button}
+          className={classnames(styles.button, styles.button_margin)}
           type="submit"
           disabled={areAllValuesSet && (formik.isSubmitting || !formik.isValid)}
           text={isAuthLoading ? 'Вход...' : 'Войти'}
         />
       </form>
 
-      <YandexOAuthButton className={classnames(styles.button)} />
+      <YandexOAuthButton className={styles.button_margin} />
 
       <StyledLink
         href={routes.register.path}

--- a/src/components/organisms/register-form/register-form.module.scss
+++ b/src/components/organisms/register-form/register-form.module.scss
@@ -18,7 +18,7 @@
 .button {
   margin: 0 auto;
   width: 236px;
-  padding: 0 22px;
+  padding: 0 24px;
 }
 
 .authLink {

--- a/src/styles/_color-variables.scss
+++ b/src/styles/_color-variables.scss
@@ -1,5 +1,6 @@
 $bg-primary: #ffffff;
 $bg-secondary: #fcfcfc;
+$bg-yandex: #000000;
 
 $dark-primary: #212329;
 $dark-secondary: #9397a3;
@@ -21,7 +22,7 @@ $success-bg: rgba(0, 128, 0, 0.12);
 // на сафари есть косяки с просто transparent
 $transparent: rgba(255, 255, 255, 0);
 
-$bg-yandex-logo: #e94f32;
+$bg-yandex-logo: #fc3f1d;
 
 :export {
   dark-primary: $dark-primary;

--- a/src/styles/_color-variables.scss
+++ b/src/styles/_color-variables.scss
@@ -23,6 +23,7 @@ $success-bg: rgba(0, 128, 0, 0.12);
 $transparent: rgba(255, 255, 255, 0);
 
 $bg-yandex-logo: #fc3f1d;
+$yandex-text-color: #fff;
 
 :export {
   dark-primary: $dark-primary;


### PR DESCRIPTION
## Связанная задача: [#352 Вынести кнопку яндекса в отдельный компонент YandexOAuthButton](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/352)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

Кнопка с авторизацией в Я.Паспорте вынесена в отдельный компонент YandexOAuthButton.
В LoginForm компонент Button был заменен на YandexOAuthButton, также из Button были удалены стили и пропсы, относящиеся к YandexOAuthButton.