### PR TITLE
enhancement/396-navigation-between-lessons

### DIFF
--- a/src/api/core/abstract/base.api.ts
+++ b/src/api/core/abstract/base.api.ts
@@ -11,6 +11,10 @@ export abstract class BaseApi {
         .then((fn) => fn());
     }
 
+    if (isMockEnv) {
+      return Promise.resolve<T>({} as T);
+    }
+
     return request();
   };
 }

--- a/src/api/lessons/index.ts
+++ b/src/api/lessons/index.ts
@@ -5,3 +5,4 @@ export type {
   TestQuestionModel,
   TestModel,
 } from './types';
+export { UserLessonProgress } from './types';

--- a/src/api/lessons/lessons.api.ts
+++ b/src/api/lessons/lessons.api.ts
@@ -10,6 +10,11 @@ class LessonsApi extends BaseApi {
       mock: () => import('./mock/lesson'),
     });
 
+  completeLesson = (id: string) =>
+    this.createRequest({
+      request: () => privateApi.get(`${SERVICE_URL}${id}/complete`),
+    });
+
   getTest = (id: number) =>
     this.createRequest<TestModel>({
       request: () => privateApi.get(`${SERVICE_URL}${id}/quiz/`),

--- a/src/api/lessons/mock/lesson.ts
+++ b/src/api/lessons/mock/lesson.ts
@@ -1,4 +1,5 @@
 import type { LessonModel } from '../types';
+import { UserLessonProgress } from '../types';
 
 const lessons: Record<string, Record<string, LessonModel>> = {
   1: {
@@ -24,6 +25,7 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      user_lesson_progress: UserLessonProgress.Finished,
       next_lesson: {
         id: 2,
         chapter_id: 1,
@@ -51,6 +53,7 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      user_lesson_progress: UserLessonProgress.Finished,
       next_lesson: {
         id: 3,
         chapter_id: 1,
@@ -82,6 +85,7 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      user_lesson_progress: UserLessonProgress.Finished,
       next_lesson: {
         id: 4,
         chapter_id: 1,
@@ -112,6 +116,7 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      user_lesson_progress: UserLessonProgress.InProgress,
       next_lesson: {
         id: 5,
         chapter_id: 1,
@@ -142,6 +147,7 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      user_lesson_progress: UserLessonProgress.NotStarted,
       next_lesson: null,
       prev_lesson: {
         id: 4,

--- a/src/api/lessons/mock/lesson.ts
+++ b/src/api/lessons/mock/lesson.ts
@@ -24,6 +24,11 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      next_lesson: {
+        id: 2,
+        chapter_id: 1,
+      },
+      prev_lesson: null,
     },
     2: {
       id: 2,
@@ -45,6 +50,14 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           id: 1,
           title: 'Курс',
         },
+      },
+      next_lesson: {
+        id: 3,
+        chapter_id: 1,
+      },
+      prev_lesson: {
+        id: 1,
+        chapter_id: 1,
       },
     },
     3: {
@@ -69,6 +82,14 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      next_lesson: {
+        id: 4,
+        chapter_id: 1,
+      },
+      prev_lesson: {
+        id: 2,
+        chapter_id: 1,
+      },
     },
     4: {
       id: 4,
@@ -91,6 +112,14 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           title: 'Курс',
         },
       },
+      next_lesson: {
+        id: 5,
+        chapter_id: 1,
+      },
+      prev_lesson: {
+        id: 3,
+        chapter_id: 1,
+      },
     },
     5: {
       id: 5,
@@ -112,6 +141,11 @@ const lessons: Record<string, Record<string, LessonModel>> = {
           id: 1,
           title: 'Курс',
         },
+      },
+      next_lesson: null,
+      prev_lesson: {
+        id: 4,
+        chapter_id: 1,
       },
     },
   },

--- a/src/api/lessons/types.ts
+++ b/src/api/lessons/types.ts
@@ -61,6 +61,12 @@ export type NextLessonModel = {
   chapter_id: number;
 };
 
+export enum UserLessonProgress {
+  NotStarted,
+  InProgress,
+  Finished,
+}
+
 export type LessonModel = {
   /** id урока */
   id?: number;
@@ -84,6 +90,8 @@ export type LessonModel = {
   diploma?: boolean;
   /** Объект хлебных крошек */
   breadcrumbs?: LessonBreadcrumbsModel;
+  /** Статус прохождения урока */
+  user_lesson_progress?: UserLessonProgress;
   /** Объект с информацией о след. уроке */
   next_lesson: Nullable<NextLessonModel>;
   /** Объект с информацией о пред. уроке */

--- a/src/api/lessons/types.ts
+++ b/src/api/lessons/types.ts
@@ -56,6 +56,11 @@ export type LessonBreadcrumbsModel = {
   };
 };
 
+export type NextLessonModel = {
+  id: number;
+  chapter_id: number;
+};
+
 export type LessonModel = {
   /** id урока */
   id?: number;
@@ -79,4 +84,8 @@ export type LessonModel = {
   diploma?: boolean;
   /** Объект хлебных крошек */
   breadcrumbs?: LessonBreadcrumbsModel;
+  /** Объект с информацией о след. уроке */
+  next_lesson: Nullable<NextLessonModel>;
+  /** Объект с информацией о пред. уроке */
+  prev_lesson: Nullable<NextLessonModel>;
 };

--- a/src/components/organisms/breadcrumbs/hooks/use-breadcrumbs.ts
+++ b/src/components/organisms/breadcrumbs/hooks/use-breadcrumbs.ts
@@ -53,7 +53,7 @@ export const useBreadcrumbs = <T extends BreadcrumbsType>(breadcrumbs: T) => {
   useEffect(() => {
     clearBreadcrumbs();
     updateBreadcrumbs();
-  }, []);
+  }, [breadcrumbs]);
 
   return breadcrumbsArray;
 };

--- a/src/components/organisms/navigation-buttons/navigation-buttons.module.scss
+++ b/src/components/organisms/navigation-buttons/navigation-buttons.module.scss
@@ -10,7 +10,3 @@
 .button {
   min-width: 184px;
 }
-
-.notClickable {
-  pointer-events: none;
-}

--- a/src/components/organisms/navigation-buttons/navigation-buttons.module.scss
+++ b/src/components/organisms/navigation-buttons/navigation-buttons.module.scss
@@ -10,3 +10,7 @@
 .button {
   min-width: 184px;
 }
+
+.notClickable {
+  pointer-events: none;
+}

--- a/src/components/organisms/navigation-buttons/navigation-buttons.tsx
+++ b/src/components/organisms/navigation-buttons/navigation-buttons.tsx
@@ -11,8 +11,8 @@ import type { NavigationButtonsProps } from './types';
 export const NavigationButtons: FC<NavigationButtonsProps> = ({
   className,
   view = 'default',
-  disabledPrev,
-  disabledNext,
+  isDisabledPrev,
+  isDisabledNext,
   onClickPrev,
   onClickNext,
 }) => (
@@ -22,18 +22,18 @@ export const NavigationButtons: FC<NavigationButtonsProps> = ({
       iconName="arrowBack"
       onClick={onClickPrev}
       className={styles.button}
-      disabled={disabledPrev}
+      disabled={isDisabledPrev}
       text="Назад"
     />
 
     {view === 'default' && (
       <Button
+        className={styles.button}
+        onClick={onClickNext}
+        disabled={isDisabledNext}
+        text="Далее"
         iconName="arrowForward"
         iconPosition="right"
-        onClick={onClickNext}
-        className={styles.button}
-        disabled={disabledNext}
-        text="Далее"
       />
     )}
 
@@ -41,7 +41,7 @@ export const NavigationButtons: FC<NavigationButtonsProps> = ({
       <Button
         className={styles.button}
         onClick={onClickNext}
-        disabled={disabledNext}
+        disabled={isDisabledNext}
         text="Завершить"
       />
     )}

--- a/src/components/organisms/navigation-buttons/navigation-buttons.tsx
+++ b/src/components/organisms/navigation-buttons/navigation-buttons.tsx
@@ -9,46 +9,41 @@ import type { NavigationButtonsProps } from './types';
  */
 
 export const NavigationButtons: FC<NavigationButtonsProps> = ({
-  classNameForContainer,
-  classNameForButtons,
-  view = 'main',
-  disabledBack,
-  disabledForward,
-  onClickBack,
-  onClickForward,
-}) => {
-  const buttonClasses = classnames(styles.button, classNameForButtons);
+  className,
+  view = 'default',
+  disabledPrev,
+  disabledNext,
+  onClickPrev,
+  onClickNext,
+}) => (
+  <div className={classnames(styles.navButtons, className)}>
+    <Button
+      view="secondary"
+      iconName="arrowBack"
+      onClick={onClickPrev}
+      className={styles.button}
+      disabled={disabledPrev}
+      text="Назад"
+    />
 
-  return (
-    <div className={classnames(styles.navButtons, classNameForContainer)}>
+    {view === 'default' && (
       <Button
-        view="secondary"
-        iconName="arrowBack"
-        onClick={onClickBack}
-        className={buttonClasses}
-        disabled={disabledBack}
-        text="Назад"
+        iconName="arrowForward"
+        iconPosition="right"
+        onClick={onClickNext}
+        className={styles.button}
+        disabled={disabledNext}
+        text="Далее"
       />
+    )}
 
-      {view === 'main' && (
-        <Button
-          iconName="arrowForward"
-          iconPosition="right"
-          onClick={onClickForward}
-          className={buttonClasses}
-          disabled={disabledForward}
-          text="Далее"
-        />
-      )}
-
-      {view === 'finish' && (
-        <Button
-          className={buttonClasses}
-          onClick={onClickForward}
-          disabled={disabledForward}
-          text="Завершить"
-        />
-      )}
-    </div>
-  );
-};
+    {view === 'finish' && (
+      <Button
+        className={styles.button}
+        onClick={onClickNext}
+        disabled={disabledNext}
+        text="Завершить"
+      />
+    )}
+  </div>
+);

--- a/src/components/organisms/navigation-buttons/types.ts
+++ b/src/components/organisms/navigation-buttons/types.ts
@@ -1,16 +1,14 @@
 export type NavigationButtonsProps = {
-  /** Текст во второй кнопке: 'main' - 'Далее', 'finish' - 'Завершить'. */
-  view?: 'main' | 'finish';
+  /** Текст во второй кнопке: 'default' - 'Далее', 'finish' - 'Завершить'. */
+  view?: 'default' | 'finish';
   /** Флаг отключения кнопки 'Назад'. */
-  disabledBack?: boolean;
+  disabledPrev?: boolean;
   /** Флаг отключения кнопки 'Далее'. */
-  disabledForward?: boolean;
-  /** Миксин для стилизации внешнего контейнера. Используйте css-класс, чтобы изменить css-свойства элемента. */
-  classNameForContainer?: string;
-  /** Миксин для стилизации кнопок. Используйте css-класс, чтобы изменить css-свойства элемента. */
-  classNameForButtons?: string;
+  disabledNext?: boolean;
+  /** Миксин для стилизации. Используйте css-класс, чтобы изменить css-свойства элемента. */
+  className?: string;
   /** Функция-обработчик клика по кнопке 'Назад'. */
-  onClickBack: VoidFunction;
+  onClickPrev: VoidFunction;
   /** Функция-обработчик клика по кнопке 'Вперед'. */
-  onClickForward: VoidFunction;
+  onClickNext: VoidFunction;
 };

--- a/src/components/organisms/navigation-buttons/types.ts
+++ b/src/components/organisms/navigation-buttons/types.ts
@@ -1,12 +1,12 @@
 export type NavigationButtonsProps = {
+  /** Миксин для стилизации. Используйте css-класс, чтобы изменить css-свойства элемента. */
+  className?: string;
   /** Текст во второй кнопке: 'default' - 'Далее', 'finish' - 'Завершить'. */
   view?: 'default' | 'finish';
   /** Флаг отключения кнопки 'Назад'. */
-  disabledPrev?: boolean;
+  isDisabledPrev?: boolean;
   /** Флаг отключения кнопки 'Далее'. */
-  disabledNext?: boolean;
-  /** Миксин для стилизации. Используйте css-класс, чтобы изменить css-свойства элемента. */
-  className?: string;
+  isDisabledNext?: boolean;
   /** Функция-обработчик клика по кнопке 'Назад'. */
   onClickPrev: VoidFunction;
   /** Функция-обработчик клика по кнопке 'Вперед'. */

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -106,7 +106,10 @@ const Lesson: FC = () => {
   }, [lesson.id, lesson.breadcrumbs]);
 
   const goToPrevLesson = () => {
-    navigate(getNextOrPrevRoute(lesson, 'prev'));
+    navigate(
+      getNextOrPrevRoute(lesson, 'prev') ||
+        `${routes.course.path}/${lesson.course_id}`
+    );
   };
 
   const goToNextLesson = () => {

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { FC, useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
 import { Loader } from 'components/molecules/loader';
@@ -11,6 +11,7 @@ import { PreviewWebinar } from 'components/organisms/preview-webinar';
 import { VideoLesson } from 'components/organisms/video-lesson';
 import { TestContent } from 'components/organisms/test-content';
 import { ErrorLocker } from 'components/organisms/error-locker';
+import { routes } from 'config';
 import {
   LOADING_PROCESS_MAP,
   ProcessEnum,
@@ -30,16 +31,14 @@ import {
 import { fetchCourseById } from 'store/course/thunk';
 import { fetchLessonById } from 'store/lesson/thunk';
 import { useEvent } from 'hooks/use-event';
-import { routes } from 'config';
 import styles from './lesson.module.scss';
 import type { LessonBreadcrumbs } from './types';
-
-// TODO https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/396
-const noop = () => {};
+import { getNextOrPrevRoute } from './utils';
 
 const Lesson: FC = () => {
   const { courseId, lessonId } = useParams();
 
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
   const contents = useAppSelector(selectCourseContents);
@@ -69,7 +68,7 @@ const Lesson: FC = () => {
     }
   }, [courseId, courseProcess]);
 
-  const breadcrumbs = () => {
+  const breadcrumbs = useMemo(() => {
     if (!lesson.id || !lesson.breadcrumbs) {
       return [];
     }
@@ -100,15 +99,20 @@ const Lesson: FC = () => {
       breadcrumbsObject.chapter,
       breadcrumbsObject.currentLesson,
     ];
+  }, [lesson.id, lesson.breadcrumbs]);
+
+  const goToPrevLesson = () => {
+    navigate(getNextOrPrevRoute(lesson, 'prev'));
+  };
+
+  const goToNextLesson = () => {
+    navigate(getNextOrPrevRoute(lesson, 'next'));
   };
 
   return (
     <>
       {lesson.breadcrumbs && (
-        <Breadcrumbs
-          className={styles.breadcrumbs}
-          breadcrumbs={breadcrumbs()}
-        />
+        <Breadcrumbs className={styles.breadcrumbs} breadcrumbs={breadcrumbs} />
       )}
 
       <div className={styles.lesson}>
@@ -145,7 +149,10 @@ const Lesson: FC = () => {
 
             {isQuiz && <TestContent />}
 
-            <NavigationButtons onClickBack={noop} onClickForward={noop} />
+            <NavigationButtons
+              onClickPrev={goToPrevLesson}
+              onClickNext={goToNextLesson}
+            />
           </div>
         )}
 

--- a/src/pages/lesson/utils.ts
+++ b/src/pages/lesson/utils.ts
@@ -1,0 +1,16 @@
+import { routes } from 'config';
+import type { LessonModel } from 'api/lessons';
+
+export const getNextOrPrevRoute = (
+  lesson: LessonModel,
+  type: 'prev' | 'next'
+): string => {
+  const nextOrPrevLesson =
+    type === 'prev' ? lesson.prev_lesson : lesson.next_lesson;
+
+  if (!nextOrPrevLesson) {
+    return '';
+  }
+
+  return `${routes.course.path}/${lesson.course_id}/${nextOrPrevLesson.chapter_id}/${nextOrPrevLesson.id}`;
+};

--- a/src/store/lesson/selectors.ts
+++ b/src/store/lesson/selectors.ts
@@ -5,3 +5,7 @@ export const selectLessonError = (state: AppState) => state.lesson.error;
 export const selectLesson = (state: AppState) => state.lesson.lesson;
 export const selectLessonType = (state: AppState) =>
   state.lesson.lesson.lesson_type;
+export const selectCompleteLessonProcess = (state: AppState) =>
+  state.lesson.completeLessonProcess;
+export const selectCompleteLessonError = (state: AppState) =>
+  state.lesson.completeLessonError;

--- a/src/store/lesson/slice.ts
+++ b/src/store/lesson/slice.ts
@@ -1,11 +1,6 @@
-import {
-  createSlice,
-  isFulfilled,
-  isPending,
-  isRejected,
-} from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
-import { fetchLessonById } from './thunk';
+import { completeLesson, fetchLessonById } from './thunk';
 import type { LessonState } from './types';
 
 const initialState: LessonState = {
@@ -15,8 +10,12 @@ const initialState: LessonState = {
     lesson_type: 'Lesson',
     tags: '',
     duration: 0,
+    next_lesson: null,
+    prev_lesson: null,
   },
   process: ProcessEnum.Initial,
+  completeLessonProcess: ProcessEnum.Initial,
+  completeLessonError: null,
   error: null,
 };
 
@@ -25,18 +24,28 @@ const lessonSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(fetchLessonById.fulfilled, (state, { payload }) => {
-      state.lesson = payload;
+    builder.addCase(completeLesson.pending, (state) => {
+      state.completeLessonProcess = ProcessEnum.Requested;
+      state.completeLessonError = null;
     });
-    builder.addMatcher(isPending(fetchLessonById), (state) => {
+    builder.addCase(completeLesson.fulfilled, (state) => {
+      state.completeLessonProcess = ProcessEnum.Succeeded;
+      state.completeLessonError = null;
+    });
+    builder.addCase(completeLesson.rejected, (state, { error }) => {
+      state.completeLessonProcess = ProcessEnum.Failed;
+      state.completeLessonError = error.message ?? GENERAL_ERROR;
+    });
+    builder.addCase(fetchLessonById.pending, (state) => {
       state.process = ProcessEnum.Requested;
       state.error = null;
     });
-    builder.addMatcher(isFulfilled(fetchLessonById), (state) => {
+    builder.addCase(fetchLessonById.fulfilled, (state, { payload }) => {
+      state.lesson = payload;
       state.process = ProcessEnum.Succeeded;
       state.error = null;
     });
-    builder.addMatcher(isRejected(fetchLessonById), (state, { error }) => {
+    builder.addCase(fetchLessonById.rejected, (state, { error }) => {
       state.process = ProcessEnum.Failed;
       state.error = error.message ?? GENERAL_ERROR;
     });

--- a/src/store/lesson/thunk.ts
+++ b/src/store/lesson/thunk.ts
@@ -8,3 +8,10 @@ export const fetchLessonById = createAsyncThunk(
     return lesson;
   }
 );
+
+export const completeLesson = createAsyncThunk(
+  'lesson/complete',
+  async (id: string) => {
+    await lessonsApi.completeLesson(id);
+  }
+);

--- a/src/store/lesson/types.ts
+++ b/src/store/lesson/types.ts
@@ -5,4 +5,6 @@ export type LessonState = {
   lesson: LessonModel;
   process: ProcessEnum;
   error: string | null;
+  completeLessonProcess: ProcessEnum;
+  completeLessonError: string | null;
 };


### PR DESCRIPTION
## Связанная задача: [Доработать навигацию между уроками](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/396)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- Добавлен запрос на завершение урока по клику на кнопку "Далее"
- Запрос на завершение выполняется только для уроков в статусе InProgress (1)
- Можно навигироваться между уроками с помощью кнопок "Назад" и "Далее"
- Если урок самый первый, то при нажатии на кнопку "Назад" пользователь переходит на страницу курса (поле `prev_lesson` должно быть `null`)
- Исправлено обновление breadcrumbs
