### PR TITLE
#431-fix-markdown-style

### DIFF
--- a/src/components/molecules/markdown/markdown.module.scss
+++ b/src/components/molecules/markdown/markdown.module.scss
@@ -3,6 +3,7 @@
 
 .markdown {
   font-family: vars.$mainFont;
+  white-space: pre-wrap;
 
   h1,
   h2,


### PR DESCRIPTION
### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

Добавила недостающих стилей в макрдаун для корректного отображения
