### PR TITLE
Enhancement-#442-Course-Page

### DIFF
--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -83,7 +83,7 @@ export type CourseModel = {
   /** Количество уроков в курсе. */
   lessons_count: number;
   /** Продолжительность курса в часах. */
-  course_duration: Nullable<number>;
+  course_duration: number;
   /** Список глав курса. */
   chapters: ChapterModel[];
   /** Статус подписки на курс. */

--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -83,7 +83,7 @@ export type CourseModel = {
   /** Количество уроков в курсе. */
   lessons_count: number;
   /** Продолжительность курса в часах. */
-  course_duration: number;
+  course_duration: Nullable<number>;
   /** Список глав курса. */
   chapters: ChapterModel[];
   /** Статус подписки на курс. */

--- a/src/api/courses/types.ts
+++ b/src/api/courses/types.ts
@@ -13,7 +13,7 @@ export type CoursePreviewModel = {
   /** Количество уроков в курсе. */
   lessons_count: number;
   /** Продолжительность курса в часах. */
-  course_duration: number;
+  course_duration: Nullable<number>;
   /** Статус курса. */
   course_status: 'active' | 'inactive' | 'finished' | 'booked';
   /** URL к обложке курса. */

--- a/src/api/courses/types.ts
+++ b/src/api/courses/types.ts
@@ -13,7 +13,7 @@ export type CoursePreviewModel = {
   /** Количество уроков в курсе. */
   lessons_count: number;
   /** Продолжительность курса в часах. */
-  course_duration: number | null;
+  course_duration: number;
   /** Статус курса. */
   course_status: 'active' | 'inactive' | 'finished' | 'booked';
   /** URL к обложке курса. */

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -55,7 +55,7 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
           </Li>
         )}
 
-        {courseDuration > 0 && (
+        {courseDuration && courseDuration > 0 && (
           <Li className={styles.courseMetaItem}>
             <TextWithIcon text="Продолжительность:" iconType="duration" />
             {courseDuration} ч

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -48,15 +48,19 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
           {level}
         </Li>
 
-        <Li className={styles.courseMetaItem}>
-          <TextWithIcon text="Количество занятий:" iconType="lessons" />
-          {lessonsCount}
-        </Li>
+        {lessonsCount > 0 && (
+          <Li className={styles.courseMetaItem}>
+            <TextWithIcon text="Количество занятий:" iconType="lessons" />
+            {lessonsCount}
+          </Li>
+        )}
 
-        <Li className={styles.courseMetaItem}>
-          <TextWithIcon text="Продолжительность:" iconType="duration" />
-          {courseDuration ?? 0} ч
-        </Li>
+        {courseDuration > 0 && (
+          <Li className={styles.courseMetaItem}>
+            <TextWithIcon text="Продолжительность:" iconType="duration" />
+            {courseDuration} ч
+          </Li>
+        )}
 
         <Li className={styles.courseMetaItem}>
           <TextWithIcon text="Старт занятий:" iconType="calendar" />

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -55,7 +55,7 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
           </Li>
         )}
 
-        {courseDuration && courseDuration > 0 && (
+        {courseDuration && (
           <Li className={styles.courseMetaItem}>
             <TextWithIcon text="Продолжительность:" iconType="duration" />
             {courseDuration} ч

--- a/src/components/organisms/course-overview/types.ts
+++ b/src/components/organisms/course-overview/types.ts
@@ -16,7 +16,7 @@ export type CourseOverviewProps = {
   /** Статус подписки на курс c бэка. */
   userStatus?: UserProgressStatus;
   /** Продолжительность курса в часах. */
-  courseDuration?: Nullable<number>;
+  courseDuration: number;
   /** Обработчик клика по кнопке. */
   onClick?: VoidFunction;
   /** Объект статуса подписки на курс */

--- a/src/components/organisms/course-overview/types.ts
+++ b/src/components/organisms/course-overview/types.ts
@@ -16,7 +16,7 @@ export type CourseOverviewProps = {
   /** Статус подписки на курс c бэка. */
   userStatus?: UserProgressStatus;
   /** Продолжительность курса в часах. */
-  courseDuration: number;
+  courseDuration: Nullable<number>;
   /** Обработчик клика по кнопке. */
   onClick?: VoidFunction;
   /** Объект статуса подписки на курс */

--- a/src/components/organisms/course-preview/course-preview.tsx
+++ b/src/components/organisms/course-preview/course-preview.tsx
@@ -62,7 +62,7 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
 
           <Tag className={styles.level} text={level} />
 
-          {duration && (
+          {duration > 0 && (
             <TextWithIcon
               className={styles.duration}
               text={`${duration} ч`}
@@ -70,11 +70,13 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
             />
           )}
 
-          <TextWithIcon
-            className={styles.lessons}
-            text={`${lessonsCount} ${GetDeclensionOf.lessons(lessonsCount)}`}
-            iconType="lessons"
-          />
+          {lessonsCount > 0 && (
+            <TextWithIcon
+              className={styles.lessons}
+              text={`${lessonsCount} ${GetDeclensionOf.lessons(lessonsCount)}`}
+              iconType="lessons"
+            />
+          )}
 
           <img
             src={coverPath || placeholderCover}

--- a/src/components/organisms/course-preview/course-preview.tsx
+++ b/src/components/organisms/course-preview/course-preview.tsx
@@ -62,7 +62,7 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
 
           <Tag className={styles.level} text={level} />
 
-          {duration && duration > 0 && (
+          {duration && (
             <TextWithIcon
               className={styles.duration}
               text={`${duration} ч`}

--- a/src/components/organisms/course-preview/course-preview.tsx
+++ b/src/components/organisms/course-preview/course-preview.tsx
@@ -62,7 +62,7 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
 
           <Tag className={styles.level} text={level} />
 
-          {duration > 0 && (
+          {duration && duration > 0 && (
             <TextWithIcon
               className={styles.duration}
               text={`${duration} ч`}

--- a/src/store/course/slice.ts
+++ b/src/store/course/slice.ts
@@ -4,13 +4,25 @@ import {
   isPending,
   isRejected,
 } from '@reduxjs/toolkit';
-import type { CourseModel } from 'api/course';
 import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
 import { fetchCourseById } from './thunk';
 import type { CourseState } from './types';
 
 const initialState: CourseState = {
-  course: {} as CourseModel,
+  course: {
+    id: 0,
+    title: '',
+    level: '',
+    full_description: '',
+    faq: [],
+    knowledge: [],
+    start_date: '',
+    cover_path: null,
+    lessons_count: 0,
+    course_duration: 0,
+    chapters: [],
+    current_lesson: { lesson: 0, chapter: 0 },
+  },
   process: ProcessEnum.Initial,
   error: null,
 };


### PR DESCRIPTION
## Связанная задача: [#442 Реализовать проверку на lessonsCount, courseDuration === 0 на главной и странице курса](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/442)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- В карточке курса и на главной странице в случае, если в количестве занятий и количестве часов указаны "0", убраны надписи "0 занятий", "0 ч". 
- Скорректирован `initialState` в `slice course` - ранее он был реализован через `course: {} as CourseModel`, что не является корректным