### PR TITLE
#454-fix-user-status-data

### DIFF
--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -12,8 +12,8 @@ export enum LessonProgress {
 }
 
 export enum UserProgressStatus {
-  Enrolled = 'True',
-  NotEnrolled = 'False',
+  Enrolled = 'enrolled',
+  NotEnrolled = 'not_enrolled',
 }
 
 export type FAQModel = {


### PR DESCRIPTION
## Связанная задача: [#454 Не отображается текст кнопок "Записаться" и "Продолжить"](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/issues/454)

### [Чеклист](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

Поправлен баг с неотображающимся текстом кнопок - на фронте ожидаются новые данные от бэка.
Сохранилась небольшая проблема на стороне бэка: у курсов, на которые пользователь раньше не был записан, новые значения в user_status работают корректно, но для тех курсов, на которые пользователь был записан раннее, бэк возвращает "1", и соответственно при них кнопки ломаются. Как вариант, который предложил бэк, - отписать пользователей от всех курсов, на которые они раннее были подписаны. 
