### PR TITLE
MIL-9-add-additional-user-enroll-statuses

### DIFF
--- a/src/api/course/mock/enroll.ts
+++ b/src/api/course/mock/enroll.ts
@@ -1,8 +1,9 @@
-import type { EnrollModel } from 'api/course/types';
+import { UserProgressStatus, type EnrollModel } from 'api/course/types';
 
 const enrollResponse: EnrollModel = {
   chapter_id: 2,
   lesson_id: 1,
+  user_status: UserProgressStatus.Available,
 };
 
 export default Promise.resolve(() => enrollResponse);

--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -14,6 +14,9 @@ export enum LessonProgress {
 export enum UserProgressStatus {
   Enrolled = 'enrolled',
   NotEnrolled = 'not_enrolled',
+  Available = 'available',
+  InProgress = 'in_progress',
+  Completed = 'completed',
 }
 
 export type FAQModel = {
@@ -92,4 +95,6 @@ export type CourseModel = {
   current_lesson?: CurrentLessonModel;
 };
 
-export type EnrollModel = CurrentLessonModel;
+export type EnrollModel = CurrentLessonModel & {
+  user_status: UserProgressStatus;
+};

--- a/src/api/courses/mock/courses.ts
+++ b/src/api/courses/mock/courses.ts
@@ -10,6 +10,7 @@ const courses: CoursesModel = {
       short_description:
         'Поисково-спасательная работа, следовая работа, а так же поиск тел погибших с помощью собак.',
       lessons_count: 144,
+      start_date: '2023-20-01',
       course_duration: 144,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/VttHZb2/1.png',
@@ -25,6 +26,7 @@ const courses: CoursesModel = {
       short_description:
         'Оперативное реагирование, контроль поступающих заявок и звонков, распределение задач, помощь в решении вопросов, удалённое взаимодействие, проактивный бег, замедленный снег, горячий чай, незамысловатый текст, призванный разорвать контейнер, поскольку это очень длинный текст и он никогда не кончится.',
       lessons_count: 101,
+      start_date: '2023-20-01',
       course_duration: 124,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/7rb0FZs/2.png',
@@ -40,6 +42,7 @@ const courses: CoursesModel = {
       short_description:
         'Применение БПЛА в поиске людей, а так же передача полученной с помощью техники информации спасательным службам.',
       lessons_count: 84,
+      start_date: '2023-20-01',
       course_duration: 152,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/0DQNPbT/3.png',
@@ -56,6 +59,7 @@ const courses: CoursesModel = {
         'Основы оказания первой помощи на поиске, юридические аспекты, базовые алгоритмы, разбор ошибок при оказания помощи на поиске.',
       lessons_count: 164,
       course_duration: 204,
+      start_date: '2023-20-01',
       course_status: 'active',
       cover_path: 'https://i.ibb.co/bvySqGp/4.png',
       current_lesson: {
@@ -70,6 +74,7 @@ const courses: CoursesModel = {
       short_description:
         'Создание ориентировок, заказ карт, связь через мини АТС, обеспечение поиска.',
       lessons_count: 87,
+      start_date: '2023-20-01',
       course_duration: 90,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/rsCGK20/5.png',
@@ -85,6 +90,7 @@ const courses: CoursesModel = {
       short_description:
         'Приём заявок на поиск людей с последующей передачей информации инфоргам.',
       lessons_count: 99,
+      start_date: '2023-20-01',
       course_duration: 120,
       course_status: 'booked',
       cover_path: 'https://i.ibb.co/XJJQ1tq/6.png',
@@ -100,6 +106,7 @@ const courses: CoursesModel = {
       short_description:
         'Прозвон больниц, ОВД, различных ведомств, иногда свидетелей и возможных свидетелей.',
       lessons_count: 55,
+      start_date: '2023-20-01',
       course_duration: 87,
       course_status: 'inactive',
       cover_path: 'https://i.ibb.co/VjVRdY1/7.png',
@@ -115,6 +122,7 @@ const courses: CoursesModel = {
       short_description:
         'Короткое описание курса. Поиск людей в лесу и в городе. Все поисковые мероприятия организуются силами добровольцев «ЛизаАлерт».',
       lessons_count: 30,
+      start_date: '2023-20-01',
       course_duration: 50,
       course_status: 'finished',
       cover_path: 'https://i.ibb.co/p1yrc4Y/8.png',

--- a/src/api/courses/mock/courses.ts
+++ b/src/api/courses/mock/courses.ts
@@ -10,7 +10,7 @@ const courses: CoursesModel = {
       short_description:
         'Поисково-спасательная работа, следовая работа, а так же поиск тел погибших с помощью собак.',
       lessons_count: 144,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 144,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/VttHZb2/1.png',
@@ -26,7 +26,7 @@ const courses: CoursesModel = {
       short_description:
         'Оперативное реагирование, контроль поступающих заявок и звонков, распределение задач, помощь в решении вопросов, удалённое взаимодействие, проактивный бег, замедленный снег, горячий чай, незамысловатый текст, призванный разорвать контейнер, поскольку это очень длинный текст и он никогда не кончится.',
       lessons_count: 101,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 124,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/7rb0FZs/2.png',
@@ -42,7 +42,7 @@ const courses: CoursesModel = {
       short_description:
         'Применение БПЛА в поиске людей, а так же передача полученной с помощью техники информации спасательным службам.',
       lessons_count: 84,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 152,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/0DQNPbT/3.png',
@@ -59,7 +59,7 @@ const courses: CoursesModel = {
         'Основы оказания первой помощи на поиске, юридические аспекты, базовые алгоритмы, разбор ошибок при оказания помощи на поиске.',
       lessons_count: 164,
       course_duration: 204,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_status: 'active',
       cover_path: 'https://i.ibb.co/bvySqGp/4.png',
       current_lesson: {
@@ -74,7 +74,7 @@ const courses: CoursesModel = {
       short_description:
         'Создание ориентировок, заказ карт, связь через мини АТС, обеспечение поиска.',
       lessons_count: 87,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 90,
       course_status: 'active',
       cover_path: 'https://i.ibb.co/rsCGK20/5.png',
@@ -90,7 +90,7 @@ const courses: CoursesModel = {
       short_description:
         'Приём заявок на поиск людей с последующей передачей информации инфоргам.',
       lessons_count: 99,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 120,
       course_status: 'booked',
       cover_path: 'https://i.ibb.co/XJJQ1tq/6.png',
@@ -106,7 +106,7 @@ const courses: CoursesModel = {
       short_description:
         'Прозвон больниц, ОВД, различных ведомств, иногда свидетелей и возможных свидетелей.',
       lessons_count: 55,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 87,
       course_status: 'inactive',
       cover_path: 'https://i.ibb.co/VjVRdY1/7.png',
@@ -122,7 +122,7 @@ const courses: CoursesModel = {
       short_description:
         'Короткое описание курса. Поиск людей в лесу и в городе. Все поисковые мероприятия организуются силами добровольцев «ЛизаАлерт».',
       lessons_count: 30,
-      start_date: '2023-20-01',
+      start_date: '2023-01-20',
       course_duration: 50,
       course_status: 'finished',
       cover_path: 'https://i.ibb.co/p1yrc4Y/8.png',

--- a/src/api/courses/types.ts
+++ b/src/api/courses/types.ts
@@ -12,6 +12,8 @@ export type CoursePreviewModel = {
   short_description: string;
   /** Количество уроков в курсе. */
   lessons_count: number;
+  /** Дата начала курса. */
+  start_date: string;
   /** Продолжительность курса в часах. */
   course_duration: Nullable<number>;
   /** Статус курса. */

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -4,7 +4,6 @@ import { Card } from 'components/atoms/card';
 import { Li } from 'components/atoms/typography';
 import { Button } from 'components/molecules/button';
 import { TextWithIcon } from 'components/molecules/text-with-icon';
-import { isDevEnv } from 'config';
 import { UserProgressStatus } from 'api/course';
 import { onImageLoadError } from 'utils/on-image-load-error';
 import { convertDate } from 'utils/convert-date';
@@ -27,12 +26,14 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
   userStatus = UserProgressStatus.NotEnrolled,
   currentLesson,
 }) => {
-  const { buttonText, handleEnroll, handleUnroll } = useEnrollCourse({
-    id,
-    userStatus,
-    enrollStatus,
-    currentLesson,
-  });
+  const { buttonText, isEnrolled, canStudy, handleEnroll, handleUnroll } =
+    useEnrollCourse({
+      id,
+      userStatus,
+      startDate,
+      enrollStatus,
+      currentLesson,
+    });
 
   return (
     <Card className={styles.courseOverview} htmlTag="article" noPadding>
@@ -76,11 +77,15 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
         color="warning"
       />
 
-      <Button className={styles.courseEnroll} onClick={handleEnroll}>
+      <Button
+        className={styles.courseEnroll}
+        onClick={handleEnroll}
+        disabled={!canStudy}
+      >
         {buttonText}
       </Button>
 
-      {isDevEnv && (
+      {isEnrolled && (
         <Button
           className={styles.courseEnroll}
           view="secondary"

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -4,6 +4,7 @@ import { Card } from 'components/atoms/card';
 import { Li } from 'components/atoms/typography';
 import { Button } from 'components/molecules/button';
 import { TextWithIcon } from 'components/molecules/text-with-icon';
+import { isDevEnv } from 'config';
 import { UserProgressStatus } from 'api/course';
 import { onImageLoadError } from 'utils/on-image-load-error';
 import { convertDate } from 'utils/convert-date';
@@ -85,7 +86,7 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
         {buttonText}
       </Button>
 
-      {isEnrolled && (
+      {isDevEnv && isEnrolled && (
         <Button
           className={styles.courseEnroll}
           view="secondary"

--- a/src/components/organisms/course-preview/course-preview.tsx
+++ b/src/components/organisms/course-preview/course-preview.tsx
@@ -33,14 +33,16 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
     short_description: description,
     lessons_count: lessonsCount,
     course_duration: duration,
+    start_date: startDate,
     cover_path: coverPath,
     user_status: userStatus,
     current_lesson: currentLesson,
   } = course;
 
-  const { isEnrolled, buttonText, handleEnroll } = useEnrollCourse({
+  const { isEnrolled, canStudy, buttonText, handleEnroll } = useEnrollCourse({
     id,
     userStatus: userStatus ?? UserProgressStatus.NotEnrolled,
+    startDate,
     enrollStatus,
     currentLesson,
   });
@@ -90,6 +92,7 @@ export const CoursePreview: FC<CoursePreviewProps> = ({
       </Link>
       <Button
         className={styles.button}
+        disabled={!canStudy}
         view={isEnrolled ? 'primary' : 'secondary'}
         onClick={handleEnroll}
       >

--- a/src/hooks/use-enroll-course.ts
+++ b/src/hooks/use-enroll-course.ts
@@ -46,13 +46,15 @@ export const useEnrollCourse = ({
   const isEnrolled = currentUserStatus !== UserProgressStatus.NotEnrolled;
   const canStudy = currentUserStatus !== UserProgressStatus.Enrolled;
 
-  const buttonText = useMemo(
-    () =>
-      currentUserStatus === UserProgressStatus.Enrolled
-        ? `Начнется ${startDate || 'скоро'}`
-        : CourseStatusButtons[currentUserStatus],
-    [currentUserStatus]
-  );
+  const buttonText = useMemo(() => {
+    const localStartDate = new Date(startDate).toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'short',
+    });
+    return currentUserStatus === UserProgressStatus.Enrolled
+      ? `Начнется ${localStartDate || 'скоро'}`
+      : CourseStatusButtons[currentUserStatus];
+  }, [currentUserStatus]);
 
   const isCurrentLessonAvailableAfterEnroll =
     typeof enrollStatus?.currentLesson?.chapter_id === 'number' &&

--- a/src/store/courses/slice.ts
+++ b/src/store/courses/slice.ts
@@ -7,7 +7,7 @@ import {
 import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
 import { UserProgressStatus } from 'api/course';
 import type { CoursesState } from './types';
-import { enrollCourseById, fetchCourses } from './thunk';
+import { enrollCourseById, unrollCourseById, fetchCourses } from './thunk';
 
 const initialState: CoursesState = {
   count: null,
@@ -47,15 +47,23 @@ export const coursesSlice = createSlice({
         currentLesson: null,
       };
     });
+    builder.addCase(unrollCourseById.fulfilled, (state, { meta: { arg } }) => {
+      state.enrollStatus[arg] = {
+        process: ProcessEnum.Succeeded,
+        error: null,
+        currentLesson: null,
+        userStatus: UserProgressStatus.NotEnrolled,
+      };
+    });
     builder.addCase(
       enrollCourseById.fulfilled,
       (state, { meta: { arg }, payload }) => {
+        const { user_status: userStatus, ...currentLesson } = payload;
         state.enrollStatus[arg] = {
           process: ProcessEnum.Succeeded,
           error: null,
-          // TODO для userStatus получать от бэка статус подписки в ответе метода enroll
-          userStatus: UserProgressStatus.Enrolled,
-          currentLesson: payload,
+          userStatus,
+          currentLesson,
         };
       }
     );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -22,7 +22,10 @@ export enum KeyboardKeys {
 
 export const CourseStatusButtons: Record<UserProgressStatus, string> = {
   [UserProgressStatus.NotEnrolled]: 'Записаться',
-  [UserProgressStatus.Enrolled]: 'Продолжить',
+  [UserProgressStatus.Enrolled]: 'Скоро начнется',
+  [UserProgressStatus.Available]: 'Начать учиться',
+  [UserProgressStatus.InProgress]: 'Продолжить',
+  [UserProgressStatus.Completed]: 'Пройти еще раз',
 };
 
 export const ErrorMessages = {


### PR DESCRIPTION
## Связанная задача: [Поддержать статусы пользователя](https://linear.app/lizaalert/issue/MIL-9/podderzhat-statusy-polzovatelya)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- для user_status добавлены варианты Available, InProgress, Completed
- добавлено поле start_date в курсах
- в courses slice добавлен extraReducer: unrollCourseById
- хук useEnrollStatus изменен в соответствии с новыми статусами user_status
- хук useEnrollStatus предоставляет дополнительное свойство canStudy, если canStudy: false кнопка "Подписаться/Начать учиться" не активна