### PR TITLE
MIL-27-add-lesson-403-error-handler

### DIFF
--- a/src/components/organisms/error-locker/error-locker-content.tsx
+++ b/src/components/organisms/error-locker/error-locker-content.tsx
@@ -8,6 +8,7 @@ import styles from './error-locker.module.scss';
 export const ErrorLockerContent: FC<ErrorLockerContentProps> = ({
   heading = GENERAL_ERROR,
   subheading,
+  content,
   buttonText = 'Попробовать ещё раз',
   onClick,
 }) => (
@@ -20,6 +21,7 @@ export const ErrorLockerContent: FC<ErrorLockerContentProps> = ({
       text={heading}
     />
     {subheading && <P text={subheading} textAlign="center" />}
+    {content && <P text={content} textAlign="center" />}
     <Button
       text={buttonText}
       onClick={onClick}

--- a/src/components/organisms/error-locker/types.ts
+++ b/src/components/organisms/error-locker/types.ts
@@ -3,6 +3,8 @@ export type ErrorLockerContentProps = {
   heading?: string;
   /** Подзаголовок-пояснение ошибки */
   subheading?: string;
+  /** Текст-пояснение ошибки */
+  content?: string;
   /** Текст кнопки */
   buttonText?: string;
   /** Функция-обработчик клика */

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -1,4 +1,5 @@
 import { FC, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import getYouTubeID from 'get-youtube-id';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
@@ -12,7 +13,12 @@ import { VideoLesson } from 'components/organisms/video-lesson';
 import { TestContent } from 'components/organisms/test-content';
 import { ErrorLocker } from 'components/organisms/error-locker';
 import { routes } from 'config';
-import { LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
+import {
+  ERROR_403,
+  LOADING_PROCESS_MAP,
+  ProcessEnum,
+  SERVER_API_ERRORS,
+} from 'utils/constants';
 import { LessonType } from 'api/course';
 import { UserLessonProgress } from 'api/lessons';
 import { useAppSelector } from 'store';
@@ -35,6 +41,7 @@ const Lesson: FC = () => {
     goToNextLesson,
   } = useLesson();
 
+  const navigate = useNavigate();
   const contents = useAppSelector(selectCourseContents);
   const lessonType = useAppSelector(selectLessonType);
   const completeLessonProcess = useAppSelector(selectCompleteLessonProcess);
@@ -87,7 +94,18 @@ const Lesson: FC = () => {
         {(isLoading || lessonError) && (
           <Card className={styles.error} htmlTag="section">
             {isLoading && <Loader />}
-            {lessonError && <ErrorLocker onClick={fetchLesson} />}
+            {lessonError &&
+              (lessonError === SERVER_API_ERRORS.FORBIDDEN ? (
+                <ErrorLocker
+                  onClick={() => navigate(-1)}
+                  heading={ERROR_403}
+                  subheading="Доступ запрещен"
+                  content="У вас нет прав доступа к этой странице"
+                  buttonText="Назад"
+                />
+              ) : (
+                <ErrorLocker onClick={fetchLesson} />
+              ))}
           </Card>
         )}
 

--- a/src/store/lesson/thunk.ts
+++ b/src/store/lesson/thunk.ts
@@ -1,9 +1,24 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { ApiInterceptorConfig, privateApi } from 'api/core';
 import { lessonsApi } from 'api/lessons';
+
+const getLessonInterceptor = (): ApiInterceptorConfig => ({
+  type: 'response',
+  name: 'lesson/fetch',
+  onFulfilled: (res) => res,
+  onRejected: async (err) => {
+    if ('detail' in err) {
+      const error = { message: err.detail };
+      return Promise.reject(error);
+    }
+    return Promise.reject(err);
+  },
+});
 
 export const fetchLessonById = createAsyncThunk(
   'lesson/fetch',
   async (id: string) => {
+    privateApi.addInterceptor(getLessonInterceptor());
     const lesson = await lessonsApi.getLesson(id);
     return lesson;
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_SIZE = 10;
 
 export const GENERAL_ERROR = 'Что-то пошло не так';
+export const ERROR_403 = 'Ошибка 403';
 
 export const ACCESS_TOKEN = 'token.access';
 export const REFRESH_TOKEN = 'token.refresh';
@@ -32,6 +33,10 @@ export const ErrorMessages = {
   email: 'Введите эл. адрес в формате: anna@liza-alert.ru',
   tel: 'Введите номер телефона в формате: +7 (XXX) XXX XX XX',
   confirmPassword: 'Пароли не совпадают',
+};
+
+export const SERVER_API_ERRORS = {
+  FORBIDDEN: 'У вас недостаточно прав для выполнения данного действия.',
 };
 
 export const RegExpPatterns = {


### PR DESCRIPTION
## Связанная задача: [[FRONT] Отображать на странице урока ошибку 403, если в ответе бекенда приходит код 403](https://linear.app/lizaalert/issue/MIL-27/[front]-otobrazhat-na-stranice-uroka-oshibku-403-esli-v-otvete-bekenda)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- Добавлен axios inspector для отлавливания 403 ошибки при загрузке
- Добавлено отображение 403 ошибки при загрузке урока в error-locker.tsx
![Снимок экрана_2024-01-26_14-10-44](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/assets/9252601/0acfa9ad-e97c-450d-96b6-585041eade52)
