### PR TITLE
MIL-26-add-course-mismatch-error

### DIFF
--- a/src/hooks/use-lesson.ts
+++ b/src/hooks/use-lesson.ts
@@ -2,15 +2,11 @@ import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { routes } from 'config';
 import { SUBROUTES } from 'router/routes';
-import {
-  LOADING_PROCESS_MAP,
-  ProcessEnum,
-  SHOULD_LOAD_PROCESS_MAP,
-} from 'utils/constants';
+import { LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
 import { getNextOrPrevRoute } from 'utils/get-next-or-prev-route';
 import { LessonModel, UserLessonProgress } from 'api/lessons';
 import { useAppDispatch, useAppSelector } from 'store';
-import { selectCourseProcess } from 'store/course/selectors';
+import { selectCourse } from 'store/course/selectors';
 import {
   selectCompleteLessonProcess,
   selectLesson,
@@ -44,7 +40,7 @@ export const useLesson = (): UseLesson => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const courseProcess = useAppSelector(selectCourseProcess);
+  const course = useAppSelector(selectCourse);
 
   const lesson = useAppSelector(selectLesson);
   const lessonProcess = useAppSelector(selectLessonProcess);
@@ -98,10 +94,19 @@ export const useLesson = (): UseLesson => {
   }, [lessonId]);
 
   useEffect(() => {
-    if (courseId && SHOULD_LOAD_PROCESS_MAP[courseProcess]) {
+    if (courseId && course.id !== Number(courseId)) {
       void dispatch(fetchCourseById(courseId));
     }
-  }, [courseId, courseProcess]);
+  }, [course, courseId]);
+
+  useEffect(() => {
+    if (
+      lessonProcess === ProcessEnum.Succeeded &&
+      lesson.course_id !== Number(courseId)
+    ) {
+      navigate(routes.notFound.path);
+    }
+  }, [lessonProcess, courseId]);
 
   useEffect(() => {
     if (courseId && completeLessonProcess === ProcessEnum.Succeeded) {

--- a/src/hooks/use-lesson.ts
+++ b/src/hooks/use-lesson.ts
@@ -16,6 +16,7 @@ import {
 import { completeLesson, fetchLessonById } from 'store/lesson/thunk';
 import { fetchCourseById } from 'store/course/thunk';
 import { useEvent } from 'hooks/use-event';
+import { resetLessonState } from 'store/lesson/slice';
 
 type UseLesson = {
   courseId: string;
@@ -91,6 +92,9 @@ export const useLesson = (): UseLesson => {
     if (lessonId && lesson.id !== +lessonId) {
       fetchLesson();
     }
+    return () => {
+      dispatch(resetLessonState());
+    };
   }, [lessonId]);
 
   useEffect(() => {
@@ -101,12 +105,13 @@ export const useLesson = (): UseLesson => {
 
   useEffect(() => {
     if (
-      lessonProcess === ProcessEnum.Succeeded &&
-      lesson.course_id !== Number(courseId)
+      lesson.id &&
+      (lesson.chapter_id !== Number(chapterId) ||
+        lesson.course_id !== Number(courseId))
     ) {
       navigate(routes.notFound.path);
     }
-  }, [lessonProcess, courseId]);
+  }, [lesson]);
 
   useEffect(() => {
     if (courseId && completeLessonProcess === ProcessEnum.Succeeded) {

--- a/src/store/lesson/slice.ts
+++ b/src/store/lesson/slice.ts
@@ -24,7 +24,9 @@ const initialState: LessonState = {
 const lessonSlice = createSlice({
   name: 'lesson',
   initialState,
-  reducers: {},
+  reducers: {
+    resetLessonState: () => initialState,
+  },
   extraReducers: (builder) => {
     builder.addCase(completeLesson.pending, (state) => {
       state.completeLessonProcess = ProcessEnum.Requested;
@@ -53,5 +55,7 @@ const lessonSlice = createSlice({
     });
   },
 });
+
+export const { resetLessonState } = lessonSlice.actions;
 
 export default lessonSlice.reducer;


### PR DESCRIPTION
## Связанная задача: [Показывать страницу 404, если id курса, главы и урока в поисковой строке не совпадают с данными по уроку](https://linear.app/lizaalert/issue/MIL-26/[front]-pokazyvat-stranicu-404-esli-id-kursa-glavy-i-uroka-v-poiskovoj)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- исправлен баг бесконечной загрузки курса при неудачной загрузке. Запрос на сервер, только если курса нет в сторе.

https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/assets/9252601/0037080f-99ce-47bf-a76d-b230663aacd9

- добавлена переадресация на страницу 404 в случае если lesson.course_id !== courseId


https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/assets/9252601/fb557909-eb77-4f6d-98a4-f20fe3006e80

