### PR TITLE
MIL-56, MIL-60: [FRONT] Вместо строки в поле ошибки в сторе сделать объект

### DIFF
--- a/src/api/core/constants.ts
+++ b/src/api/core/constants.ts
@@ -1,3 +1,23 @@
-export enum HttpCodes {
+export enum HttpStatusCodes {
+  BadRequest = 400,
   Unauthorized = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Internal = 500,
 }
+
+export enum HttpCodes {
+  BadRequest = 'BAD_REQUEST',
+  Unauthorized = 'UNAUTHORIZED',
+  Forbidden = 'FORBIDDEN',
+  NotFound = 'NOT_FOUND',
+  Internal = 'INTERNAL',
+}
+
+export const httpStatusCodesMap: Record<HttpStatusCodes | number, HttpCodes> = {
+  [HttpStatusCodes.BadRequest]: HttpCodes.BadRequest,
+  [HttpStatusCodes.Unauthorized]: HttpCodes.Unauthorized,
+  [HttpStatusCodes.Forbidden]: HttpCodes.Forbidden,
+  [HttpStatusCodes.NotFound]: HttpCodes.NotFound,
+  [HttpStatusCodes.Internal]: HttpCodes.Internal,
+};

--- a/src/api/core/constants.ts
+++ b/src/api/core/constants.ts
@@ -6,7 +6,7 @@ export enum HttpStatusCodes {
   Internal = 500,
 }
 
-export enum HttpCodes {
+export enum ErrorCodes {
   BadRequest = 'BAD_REQUEST',
   Unauthorized = 'UNAUTHORIZED',
   Forbidden = 'FORBIDDEN',
@@ -14,10 +14,11 @@ export enum HttpCodes {
   Internal = 'INTERNAL',
 }
 
-export const httpStatusCodesMap: Record<HttpStatusCodes | number, HttpCodes> = {
-  [HttpStatusCodes.BadRequest]: HttpCodes.BadRequest,
-  [HttpStatusCodes.Unauthorized]: HttpCodes.Unauthorized,
-  [HttpStatusCodes.Forbidden]: HttpCodes.Forbidden,
-  [HttpStatusCodes.NotFound]: HttpCodes.NotFound,
-  [HttpStatusCodes.Internal]: HttpCodes.Internal,
-};
+export const httpStatusCodesMap: Record<HttpStatusCodes | number, ErrorCodes> =
+  {
+    [HttpStatusCodes.BadRequest]: ErrorCodes.BadRequest,
+    [HttpStatusCodes.Unauthorized]: ErrorCodes.Unauthorized,
+    [HttpStatusCodes.Forbidden]: ErrorCodes.Forbidden,
+    [HttpStatusCodes.NotFound]: ErrorCodes.NotFound,
+    [HttpStatusCodes.Internal]: ErrorCodes.Internal,
+  };

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,6 +1,6 @@
 export { publicApi } from './public.api';
 export { privateApi } from './private.api';
 export { BaseApi } from './abstract/base.api';
-export { HttpCodes, HttpStatusCodes } from './constants';
+export { ErrorCodes, HttpStatusCodes } from './constants';
 export { SerializedError } from './serialized-error';
 export type { ApiInterceptorConfig } from './types';

--- a/src/api/core/index.ts
+++ b/src/api/core/index.ts
@@ -1,5 +1,6 @@
 export { publicApi } from './public.api';
 export { privateApi } from './private.api';
 export { BaseApi } from './abstract/base.api';
-export { HttpCodes } from './constants';
+export { HttpCodes, HttpStatusCodes } from './constants';
+export { SerializedError } from './serialized-error';
 export type { ApiInterceptorConfig } from './types';

--- a/src/api/core/public.api.ts
+++ b/src/api/core/public.api.ts
@@ -1,16 +1,5 @@
-import type { AxiosError, AxiosResponse } from 'axios';
 import { CoreApi } from './abstract/core.api';
 
-class PublicApi extends CoreApi {
-  constructor() {
-    super();
-    this.api.interceptors.response.use(
-      // Типизация возвращаемого значения производится в методах
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      (response: AxiosResponse) => response.data,
-      (error: AxiosError) => Promise.reject(error.response?.data)
-    );
-  }
-}
+class PublicApi extends CoreApi {}
 
 export const publicApi = new PublicApi();

--- a/src/api/core/serialized-error.ts
+++ b/src/api/core/serialized-error.ts
@@ -1,0 +1,13 @@
+import { GENERAL_ERROR } from 'utils/constants';
+import type { SerializedErrorType } from './types';
+
+export class SerializedError {
+  code?: SerializedErrorType['code'];
+
+  message?: SerializedErrorType['message'];
+
+  constructor({ code, message }: SerializedErrorType) {
+    this.code = code;
+    this.message = message ?? GENERAL_ERROR;
+  }
+}

--- a/src/api/core/types.ts
+++ b/src/api/core/types.ts
@@ -42,3 +42,12 @@ export type ApiInterceptorConfig = (
   name: string;
   onRejected?: (error: AxiosError) => unknown;
 };
+
+export type SerializedErrorType = {
+  code?: string;
+  message?: string;
+};
+
+export type ErrorResponseDataModel = {
+  detail: string;
+};

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1,3 +1,8 @@
 export { courseApi } from './course.api';
-export type { CourseModel, ChapterModel, LessonChapterModel } from './types';
+export type {
+  CourseModel,
+  ChapterModel,
+  LessonChapterModel,
+  CurrentLessonModel,
+} from './types';
 export { UserProgressStatus, LessonType, LessonProgress } from './types';

--- a/src/api/course/mock/current-lesson.ts
+++ b/src/api/course/mock/current-lesson.ts
@@ -1,7 +1,7 @@
 import { CurrentLessonModel } from 'api/course/types';
 
 const currentLessonResponse: CurrentLessonModel = {
-  chapter_id: 2,
+  chapter_id: 1,
   lesson_id: 1,
 };
 

--- a/src/components/organisms/course-overview/types.ts
+++ b/src/components/organisms/course-overview/types.ts
@@ -15,7 +15,7 @@ export type CourseOverviewProps = {
   /** Статус подписки на курс c бэка. */
   userStatus?: UserProgressStatus;
   /** Продолжительность курса в часах. */
-  courseDuration: Nullable<number>;
+  courseDuration?: Nullable<number>;
   /** Обработчик клика по кнопке. */
   onClick?: VoidFunction;
   /** Объект статуса подписки на курс */

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -23,6 +23,6 @@ declare module '*.jpeg' {
   export default content;
 }
 
-declare type Nullable<T> = T | null | undefined;
+declare type Nullable<T> = T | null;
 declare type VoidFunction = (...args: unknown[]) => void;
 declare type AnyFunction<T> = (...args: never) => T;

--- a/src/hooks/use-lesson.ts
+++ b/src/hooks/use-lesson.ts
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { routes } from 'config';
 import { SUBROUTES } from 'router/routes';
 import { LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
-import { HttpCodes, SerializedError } from 'api/core';
+import { SerializedError } from 'api/core';
 import { getNextOrPrevRoute } from 'utils/get-next-or-prev-route';
 import { LessonModel, UserLessonProgress } from 'api/lessons';
 import { useAppDispatch, useAppSelector } from 'store';
@@ -25,7 +25,7 @@ type UseLesson = {
   lesson: LessonModel;
   lessonProcess: ProcessEnum;
   isLoading: boolean;
-  lessonError: SerializedError | null;
+  lessonError: Nullable<SerializedError>;
   fetchLesson: VoidFunction;
   goToPrevLesson: VoidFunction;
   goToNextLesson: VoidFunction;
@@ -106,17 +106,18 @@ export const useLesson = (): UseLesson => {
   }, [course, courseId]);
 
   useEffect(() => {
-    const isNotFoundServerError = lessonError?.code === HttpCodes.NotFound;
-    const isInconsistencyError =
-      lessonProcess === ProcessEnum.Succeeded &&
-      (lesson.id !== +lessonId ||
-        lesson.chapter_id !== +chapterId ||
-        lesson.course_id !== +courseId);
+    const isDataInconsistent =
+      lesson.id !== +lessonId ||
+      lesson.chapter_id !== +chapterId ||
+      lesson.course_id !== +courseId;
 
-    if (isNotFoundServerError || isInconsistencyError) {
+    const isInconsistencyError =
+      lessonProcess === ProcessEnum.Succeeded && isDataInconsistent;
+
+    if (isInconsistencyError) {
       navigate(routes.notFound.path, { replace: true });
     }
-  }, [lessonProcess, lesson, lessonError]);
+  }, [lessonProcess, lesson]);
 
   useEffect(() => {
     if (courseId && completeLessonProcess === ProcessEnum.Succeeded) {

--- a/src/hooks/use-lesson.ts
+++ b/src/hooks/use-lesson.ts
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { routes } from 'config';
 import { SUBROUTES } from 'router/routes';
 import { LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
+import { HttpCodes, SerializedError } from 'api/core';
 import { getNextOrPrevRoute } from 'utils/get-next-or-prev-route';
 import { LessonModel, UserLessonProgress } from 'api/lessons';
 import { useAppDispatch, useAppSelector } from 'store';
@@ -24,7 +25,7 @@ type UseLesson = {
   lesson: LessonModel;
   lessonProcess: ProcessEnum;
   isLoading: boolean;
-  lessonError: string | null;
+  lessonError: SerializedError | null;
   fetchLesson: VoidFunction;
   goToPrevLesson: VoidFunction;
   goToNextLesson: VoidFunction;
@@ -89,29 +90,33 @@ export const useLesson = (): UseLesson => {
   });
 
   useEffect(() => {
-    if (lessonId && lesson.id !== +lessonId) {
+    if (lessonId) {
       fetchLesson();
     }
+
     return () => {
       dispatch(resetLessonState());
     };
   }, [lessonId]);
 
   useEffect(() => {
-    if (courseId && course.id !== Number(courseId)) {
+    if (courseId && course.id !== +courseId) {
       void dispatch(fetchCourseById(courseId));
     }
   }, [course, courseId]);
 
   useEffect(() => {
-    if (
-      lesson.id &&
-      (lesson.chapter_id !== Number(chapterId) ||
-        lesson.course_id !== Number(courseId))
-    ) {
-      navigate(routes.notFound.path);
+    const isNotFoundServerError = lessonError?.code === HttpCodes.NotFound;
+    const isInconsistencyError =
+      lessonProcess === ProcessEnum.Succeeded &&
+      (lesson.id !== +lessonId ||
+        lesson.chapter_id !== +chapterId ||
+        lesson.course_id !== +courseId);
+
+    if (isNotFoundServerError || isInconsistencyError) {
+      navigate(routes.notFound.path, { replace: true });
     }
-  }, [lesson]);
+  }, [lessonProcess, lesson, lessonError]);
 
   useEffect(() => {
     if (courseId && completeLessonProcess === ProcessEnum.Succeeded) {

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react';
-import { useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import getYouTubeID from 'get-youtube-id';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
@@ -13,12 +13,8 @@ import { VideoLesson } from 'components/organisms/video-lesson';
 import { TestContent } from 'components/organisms/test-content';
 import { ErrorLocker } from 'components/organisms/error-locker';
 import { routes } from 'config';
-import {
-  ERROR_403,
-  LOADING_PROCESS_MAP,
-  ProcessEnum,
-  SERVER_API_ERRORS,
-} from 'utils/constants';
+import { ERROR_403, LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
+import { HttpCodes } from 'api/core';
 import { LessonType } from 'api/course';
 import { UserLessonProgress } from 'api/lessons';
 import { useAppSelector } from 'store';
@@ -84,10 +80,6 @@ const Lesson: FC = () => {
     lesson.user_lesson_progress === UserLessonProgress.NotStarted ||
     LOADING_PROCESS_MAP[completeLessonProcess];
 
-  if (lessonError && lessonError === SERVER_API_ERRORS.NOT_FOUND) {
-    return <Navigate to={routes.notFound.path} />;
-  }
-
   return (
     <>
       {lesson.breadcrumbs && (
@@ -99,7 +91,7 @@ const Lesson: FC = () => {
           <Card className={styles.error} htmlTag="section">
             {isLoading && <Loader />}
             {lessonError &&
-              (lessonError === SERVER_API_ERRORS.FORBIDDEN ? (
+              (lessonError.code === HttpCodes.Forbidden ? (
                 <ErrorLocker
                   onClick={() => navigate(-1)}
                   heading={ERROR_403}

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import getYouTubeID from 'get-youtube-id';
 import { Card } from 'components/atoms/card';
 import { Heading } from 'components/atoms/typography';
@@ -14,7 +14,7 @@ import { TestContent } from 'components/organisms/test-content';
 import { ErrorLocker } from 'components/organisms/error-locker';
 import { routes } from 'config';
 import { ERROR_403, LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
-import { HttpCodes } from 'api/core';
+import { ErrorCodes } from 'api/core';
 import { LessonType } from 'api/course';
 import { UserLessonProgress } from 'api/lessons';
 import { useAppSelector } from 'store';
@@ -80,6 +80,10 @@ const Lesson: FC = () => {
     lesson.user_lesson_progress === UserLessonProgress.NotStarted ||
     LOADING_PROCESS_MAP[completeLessonProcess];
 
+  if (lessonError?.code === ErrorCodes.NotFound) {
+    return <Navigate to={routes.notFound.path} replace />;
+  }
+
   return (
     <>
       {lesson.breadcrumbs && (
@@ -91,7 +95,7 @@ const Lesson: FC = () => {
           <Card className={styles.error} htmlTag="section">
             {isLoading && <Loader />}
             {lessonError &&
-              (lessonError.code === HttpCodes.Forbidden ? (
+              (lessonError.code === ErrorCodes.Forbidden ? (
                 <ErrorLocker
                   onClick={() => navigate(-1)}
                   heading={ERROR_403}

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -1,5 +1,8 @@
+import { LOADING_PROCESS_MAP } from 'utils/constants';
 import type { AppState } from '../types';
 
-export const selectIsAuthLoading = (state: AppState) => state.auth.isLoading;
+export const selectIsAuthLoading = (state: AppState) =>
+  LOADING_PROCESS_MAP[state.auth.process];
+export const selectAuthProcess = (state: AppState) => state.auth.process;
 export const selectAuthError = (state: AppState) => state.auth.error;
 export const selectIsAuth = (state: AppState) => state.auth.isAuth;

--- a/src/store/auth/slice.ts
+++ b/src/store/auth/slice.ts
@@ -4,13 +4,13 @@ import {
   isPending,
   isRejected,
 } from '@reduxjs/toolkit';
-import { GENERAL_ERROR } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import { checkAuth, fetchAuth, fetchRegistration, logout } from './thunk';
 import type { AuthState } from './types';
 
 const initialState: AuthState = {
   isAuth: false,
-  isLoading: true,
+  process: ProcessEnum.Initial,
   error: null,
 };
 
@@ -20,20 +20,20 @@ export const authSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(fetchRegistration.fulfilled, (state) => {
-      state.isLoading = false;
+      state.process = ProcessEnum.Succeeded;
       state.error = null;
     });
     builder.addMatcher(
       isPending(checkAuth, fetchAuth, fetchRegistration, logout),
       (state) => {
-        state.isLoading = true;
+        state.process = ProcessEnum.Requested;
         state.error = null;
       }
     );
     builder.addMatcher(
       isFulfilled(checkAuth, fetchAuth, logout),
       (state, { payload }) => {
-        state.isLoading = false;
+        state.process = ProcessEnum.Succeeded;
         state.error = null;
         state.isAuth = payload;
       }
@@ -42,8 +42,8 @@ export const authSlice = createSlice({
       isRejected(checkAuth, fetchAuth, fetchRegistration, logout),
       (state, { error }) => {
         state.isAuth = false;
-        state.isLoading = false;
-        state.error = error.message ?? GENERAL_ERROR;
+        state.process = ProcessEnum.Failed;
+        state.error = error;
       }
     );
   },

--- a/src/store/auth/thunk.ts
+++ b/src/store/auth/thunk.ts
@@ -4,7 +4,7 @@ import {
   LoginFormData,
   RegistrationFormData,
 } from 'api/authorization';
-import { ApiInterceptorConfig, HttpCodes, privateApi } from 'api/core';
+import { ApiInterceptorConfig, HttpStatusCodes, privateApi } from 'api/core';
 import { ACCESS_TOKEN, REFRESH_TOKEN } from 'utils/constants';
 import type { ApiThunkConfig, ThunkApiDispatch } from '../types';
 import { checkAuthToken, refreshAuthToken } from './helpers';
@@ -38,12 +38,11 @@ const getAuthInterceptor = (
 ): ApiInterceptorConfig => ({
   type: 'response',
   name: 'auth/refresh-token',
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  onFulfilled: (res) => res.data,
+  onFulfilled: (res) => res,
   // eslint-disable-next-line consistent-return
   onRejected: async (err) => {
-    if (err.response?.status !== HttpCodes.Unauthorized) {
-      return Promise.reject(err.response?.data);
+    if (err.response?.status !== HttpStatusCodes.Unauthorized) {
+      return Promise.reject(err);
     }
 
     try {

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -1,5 +1,8 @@
+import { SerializedError } from 'api/core';
+import { ProcessEnum } from 'utils/constants';
+
 export type AuthState = {
   isAuth: boolean;
-  isLoading: boolean;
-  error: null | string;
+  process: ProcessEnum;
+  error: SerializedError | null;
 };

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -4,5 +4,5 @@ import { ProcessEnum } from 'utils/constants';
 export type AuthState = {
   isAuth: boolean;
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
 };

--- a/src/store/course/slice.ts
+++ b/src/store/course/slice.ts
@@ -4,7 +4,7 @@ import {
   isPending,
   isRejected,
 } from '@reduxjs/toolkit';
-import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import { fetchCourseById } from './thunk';
 import type { CourseState } from './types';
 
@@ -44,7 +44,7 @@ export const courseSlice = createSlice({
     });
     builder.addMatcher(isRejected(fetchCourseById), (state, { error }) => {
       state.process = ProcessEnum.Failed;
-      state.error = error.message ?? GENERAL_ERROR;
+      state.error = error;
     });
   },
 });

--- a/src/store/course/types.ts
+++ b/src/store/course/types.ts
@@ -5,5 +5,5 @@ import { ProcessEnum } from 'utils/constants';
 export type CourseState = {
   course: CourseModel;
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
 };

--- a/src/store/course/types.ts
+++ b/src/store/course/types.ts
@@ -1,8 +1,9 @@
 import type { CourseModel } from 'api/course';
+import { SerializedError } from 'api/core';
 import { ProcessEnum } from 'utils/constants';
 
 export type CourseState = {
   course: CourseModel;
   process: ProcessEnum;
-  error: string | null;
+  error: SerializedError | null;
 };

--- a/src/store/courses-filters/slice.ts
+++ b/src/store/courses-filters/slice.ts
@@ -4,7 +4,7 @@ import {
   isPending,
   isRejected,
 } from '@reduxjs/toolkit';
-import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import type { CoursesFiltersState } from './types';
 import { fetchFilters } from './thunk';
 
@@ -32,7 +32,7 @@ export const coursesFiltersSlice = createSlice({
     });
     builder.addMatcher(isRejected(fetchFilters), (state, { error }) => {
       state.process = ProcessEnum.Failed;
-      state.error = error.message ?? GENERAL_ERROR;
+      state.error = error;
     });
   },
 });

--- a/src/store/courses-filters/types.ts
+++ b/src/store/courses-filters/types.ts
@@ -1,9 +1,10 @@
+import { SerializedError } from 'api/core';
 import type { CoursesFiltersModel } from 'api/courses-filters';
 import { ProcessEnum } from 'utils/constants';
 
 export type CoursesFiltersThunkState = {
   process: ProcessEnum;
-  error: string | null;
+  error: SerializedError | null;
   filters: CoursesFiltersModel;
 };
 

--- a/src/store/courses-filters/types.ts
+++ b/src/store/courses-filters/types.ts
@@ -4,7 +4,7 @@ import { ProcessEnum } from 'utils/constants';
 
 export type CoursesFiltersThunkState = {
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
   filters: CoursesFiltersModel;
 };
 

--- a/src/store/courses/slice.ts
+++ b/src/store/courses/slice.ts
@@ -4,7 +4,7 @@ import {
   isPending,
   isRejected,
 } from '@reduxjs/toolkit';
-import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import { UserProgressStatus } from 'api/course';
 import type { CoursesState } from './types';
 import {
@@ -44,6 +44,7 @@ export const coursesSlice = createSlice({
 
       state.count = payload.count;
     });
+
     builder.addCase(enrollCourseById.pending, (state, { meta: { arg } }) => {
       state.enrollStatus[arg] = {
         ...state.enrollStatus[arg],
@@ -70,11 +71,12 @@ export const coursesSlice = createSlice({
         state.enrollStatus[arg] = {
           ...state.enrollStatus[arg],
           process: ProcessEnum.Failed,
-          error: error.message ?? GENERAL_ERROR,
+          error,
           userStatus: UserProgressStatus.NotEnrolled,
         };
       }
     );
+
     builder.addCase(unrollCourseById.fulfilled, (state, { meta: { arg } }) => {
       state.enrollStatus[arg] = {
         ...state.enrollStatus[arg],
@@ -83,6 +85,7 @@ export const coursesSlice = createSlice({
         userStatus: UserProgressStatus.NotEnrolled,
       };
     });
+
     builder.addCase(getCurrentLesson.pending, (state, { meta: { arg } }) => {
       state.enrollStatus[arg] = {
         ...state.enrollStatus[arg],
@@ -115,13 +118,14 @@ export const coursesSlice = createSlice({
           ...state.enrollStatus[arg],
           currentLesson: {
             process: ProcessEnum.Failed,
-            error: error.message ?? GENERAL_ERROR,
+            error,
             lessonId: null,
             chapterId: null,
           },
         };
       }
     );
+
     builder.addMatcher(isPending(fetchCourses), (state) => {
       state.process = ProcessEnum.Requested;
       state.error = null;
@@ -132,7 +136,7 @@ export const coursesSlice = createSlice({
     });
     builder.addMatcher(isRejected(fetchCourses), (state, { error }) => {
       state.process = ProcessEnum.Failed;
-      state.error = error.message ?? GENERAL_ERROR;
+      state.error = error;
     });
   },
 });

--- a/src/store/courses/types.ts
+++ b/src/store/courses/types.ts
@@ -5,11 +5,11 @@ import { ProcessEnum } from 'utils/constants';
 
 export type EnrollStatusType = {
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
   userStatus: UserProgressStatus;
   currentLesson?: {
     process: ProcessEnum;
-    error: SerializedError | null;
+    error: Nullable<SerializedError>;
     lessonId: CurrentLessonModel['lesson_id'];
     chapterId: CurrentLessonModel['chapter_id'];
   };
@@ -17,7 +17,7 @@ export type EnrollStatusType = {
 
 export type CoursesThunkState = {
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
   count: CoursesModel['count'];
   courses: CoursesModel['results'];
   enrollStatus: Record<string, EnrollStatusType>;

--- a/src/store/courses/types.ts
+++ b/src/store/courses/types.ts
@@ -1,14 +1,15 @@
-import type { CoursesModel } from 'api/courses/types';
-import type { CurrentLessonModel, UserProgressStatus } from 'api/course/types';
+import { SerializedError } from 'api/core';
+import type { CoursesModel } from 'api/courses';
+import type { CurrentLessonModel, UserProgressStatus } from 'api/course';
 import { ProcessEnum } from 'utils/constants';
 
 export type EnrollStatusType = {
   process: ProcessEnum;
-  error: string | null;
+  error: SerializedError | null;
   userStatus: UserProgressStatus;
   currentLesson?: {
     process: ProcessEnum;
-    error: string | null;
+    error: SerializedError | null;
     lessonId: CurrentLessonModel['lesson_id'];
     chapterId: CurrentLessonModel['chapter_id'];
   };
@@ -16,7 +17,7 @@ export type EnrollStatusType = {
 
 export type CoursesThunkState = {
   process: ProcessEnum;
-  error: string | null;
+  error: SerializedError | null;
   count: CoursesModel['count'];
   courses: CoursesModel['results'];
   enrollStatus: Record<string, EnrollStatusType>;

--- a/src/store/lesson/slice.ts
+++ b/src/store/lesson/slice.ts
@@ -1,8 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import { LessonType } from 'api/course';
 import { completeLesson, fetchLessonById } from './thunk';
 import type { LessonState } from './types';
+
+const initialNextLesson: LessonState['lesson']['next_lesson'] = {
+  chapter_id: null,
+  lesson_id: null,
+};
 
 const initialState: LessonState = {
   lesson: {
@@ -12,8 +17,8 @@ const initialState: LessonState = {
     lesson_type: LessonType.Lesson,
     tags: '',
     duration: 0,
-    next_lesson: null,
-    prev_lesson: null,
+    next_lesson: initialNextLesson,
+    prev_lesson: initialNextLesson,
   },
   process: ProcessEnum.Initial,
   completeLessonProcess: ProcessEnum.Initial,
@@ -38,8 +43,9 @@ const lessonSlice = createSlice({
     });
     builder.addCase(completeLesson.rejected, (state, { error }) => {
       state.completeLessonProcess = ProcessEnum.Failed;
-      state.completeLessonError = error.message ?? GENERAL_ERROR;
+      state.completeLessonError = error;
     });
+
     builder.addCase(fetchLessonById.pending, (state) => {
       state.process = ProcessEnum.Requested;
       state.error = null;
@@ -51,7 +57,7 @@ const lessonSlice = createSlice({
     });
     builder.addCase(fetchLessonById.rejected, (state, { error }) => {
       state.process = ProcessEnum.Failed;
-      state.error = error.message ?? GENERAL_ERROR;
+      state.error = error;
     });
   },
 });

--- a/src/store/lesson/thunk.ts
+++ b/src/store/lesson/thunk.ts
@@ -1,24 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { ApiInterceptorConfig, privateApi } from 'api/core';
 import { lessonsApi } from 'api/lessons';
-
-const getLessonInterceptor = (): ApiInterceptorConfig => ({
-  type: 'response',
-  name: 'lesson/fetch',
-  onFulfilled: (res) => res,
-  onRejected: async (err) => {
-    if ('detail' in err) {
-      const error = { message: err.detail };
-      return Promise.reject(error);
-    }
-    return Promise.reject(err);
-  },
-});
 
 export const fetchLessonById = createAsyncThunk(
   'lesson/fetch',
   async (id: string) => {
-    privateApi.addInterceptor(getLessonInterceptor());
     const lesson = await lessonsApi.getLesson(id);
     return lesson;
   }

--- a/src/store/lesson/types.ts
+++ b/src/store/lesson/types.ts
@@ -1,10 +1,11 @@
+import { SerializedError } from 'api/core';
 import type { LessonModel } from 'api/lessons';
 import { ProcessEnum } from 'utils/constants';
 
 export type LessonState = {
   lesson: LessonModel;
   process: ProcessEnum;
-  error: string | null;
+  error: SerializedError | null;
   completeLessonProcess: ProcessEnum;
-  completeLessonError: string | null;
+  completeLessonError: SerializedError | null;
 };

--- a/src/store/lesson/types.ts
+++ b/src/store/lesson/types.ts
@@ -5,7 +5,7 @@ import { ProcessEnum } from 'utils/constants';
 export type LessonState = {
   lesson: LessonModel;
   process: ProcessEnum;
-  error: SerializedError | null;
+  error: Nullable<SerializedError>;
   completeLessonProcess: ProcessEnum;
-  completeLessonError: SerializedError | null;
+  completeLessonError: Nullable<SerializedError>;
 };

--- a/src/store/profile/slice.ts
+++ b/src/store/profile/slice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { GENERAL_ERROR, ProcessEnum } from 'utils/constants';
+import { ProcessEnum } from 'utils/constants';
 import { editProfile, fetchProfile } from './thunk';
 import type { ProfileState } from './types';
 
@@ -44,7 +44,7 @@ export const profileSlice = createSlice({
     });
     builder.addCase(fetchProfile.rejected, (state, { error }) => {
       state.fetchProfileProcess = ProcessEnum.Failed;
-      state.fetchProfileError = error.message ?? GENERAL_ERROR;
+      state.fetchProfileError = error;
     });
     builder.addCase(editProfile.pending, (state) => {
       state.editProfileProcess = ProcessEnum.Requested;
@@ -56,7 +56,7 @@ export const profileSlice = createSlice({
     });
     builder.addCase(editProfile.rejected, (state, { error }) => {
       state.editProfileProcess = ProcessEnum.Failed;
-      state.editProfileError = error.message ?? GENERAL_ERROR;
+      state.editProfileError = error;
     });
   },
 });

--- a/src/store/profile/types.ts
+++ b/src/store/profile/types.ts
@@ -5,16 +5,16 @@ export type ProfileState = {
   profile: {
     id: number;
     personalData: {
-      full_name: string | null;
-      birth_date: string | null;
-      location: string | null;
+      full_name: Nullable<string>;
+      birth_date: Nullable<string>;
+      location: Nullable<string>;
     };
     accountOverview: {
       full_name: string;
-      count_pass_course: number | null;
-      department: string | null;
-      call_sign: string | null;
-      photo: string | null;
+      count_pass_course: Nullable<number>;
+      department: Nullable<string>;
+      call_sign: Nullable<string>;
+      photo: Nullable<string>;
     };
     accountData: {
       phone_number: string;
@@ -22,7 +22,7 @@ export type ProfileState = {
     };
   };
   editProfileProcess: ProcessEnum;
-  editProfileError: SerializedError | null;
+  editProfileError: Nullable<SerializedError>;
   fetchProfileProcess: ProcessEnum;
-  fetchProfileError: SerializedError | null;
+  fetchProfileError: Nullable<SerializedError>;
 };

--- a/src/store/profile/types.ts
+++ b/src/store/profile/types.ts
@@ -1,3 +1,4 @@
+import { SerializedError } from 'api/core';
 import { ProcessEnum } from 'utils/constants';
 
 export type ProfileState = {
@@ -21,7 +22,7 @@ export type ProfileState = {
     };
   };
   editProfileProcess: ProcessEnum;
-  editProfileError: string | null;
+  editProfileError: SerializedError | null;
   fetchProfileProcess: ProcessEnum;
-  fetchProfileError: string | null;
+  fetchProfileError: SerializedError | null;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -33,17 +33,6 @@ export const CourseStatusButtons: Record<UserProgressStatus, string> = {
   [UserProgressStatus.Completed]: 'Пройти еще раз',
 };
 
-export const ErrorMessages = {
-  email: 'Введите эл. адрес в формате: anna@liza-alert.ru',
-  tel: 'Введите номер телефона в формате: +7 (XXX) XXX XX XX',
-  confirmPassword: 'Пароли не совпадают',
-};
-
-export const SERVER_API_ERRORS = {
-  FORBIDDEN: 'У вас недостаточно прав для выполнения данного действия.',
-  NOT_FOUND: 'Страница не найдена.',
-};
-
 export const RegExpPatterns = {
   email: '[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$',
   phone: /^\+7 \(\d\d\d\) \d\d\d-\d\d-\d\d$/,


### PR DESCRIPTION
## Связанная задача: [[FRONT] Вместо строки в поле ошибки в сторе сделать объект](https://linear.app/lizaalert/issue/MIL-56/[front]-vmesto-stroki-v-pole-oshibki-v-store-sdelat-obuekt)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- В поле ошибки в сторе теперь хранится SerializedError (кроме стора test -- ждем, пока ПР #497 будет доработан)
- Интерсепторы теперь есть для приватного и публичного апи, ответы сервера обрабатываются одинаково
- Изменена обработка ошибок на странице урока: теперь они привязаны к кодам ответа вместо текстового пояснения ошибки
