### PR TITLE
MIL-82: Если в адресной строке дописать в конце URL "/comlete" при прохождении урока и нажать Enter, то проиcходит переброс на страницу завершений курса

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -5,4 +5,4 @@ export type {
   LessonChapterModel,
   CurrentLessonModel,
 } from './types';
-export { UserProgressStatus, LessonType, LessonProgress } from './types';
+export { UserProgressStatus } from './types';

--- a/src/api/course/mock/course.ts
+++ b/src/api/course/mock/course.ts
@@ -1,4 +1,5 @@
-import { CourseModel, LessonProgress, LessonType } from '../types';
+import { LessonType, UserLessonProgress } from 'api/lessons';
+import type { CourseModel } from '../types';
 
 const course: CourseModel = {
   id: 1,
@@ -61,7 +62,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Дрессировка поисково-спасательных собак',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 2,
@@ -69,7 +70,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Видео',
           lesson_type: LessonType.Videolesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 3,
@@ -77,7 +78,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Урок',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 4,
@@ -85,7 +86,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 5,
@@ -93,7 +94,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
       ],
     },
@@ -108,7 +109,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Дрессировка поисково-спасательных собак',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 4,
@@ -116,7 +117,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 3,
@@ -124,7 +125,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Урок',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 2,
@@ -132,7 +133,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Видео',
           lesson_type: LessonType.Videolesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 5,
@@ -140,7 +141,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
       ],
     },
@@ -155,7 +156,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Дрессировка поисково-спасательных собак',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 2,
@@ -163,7 +164,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Видео',
           lesson_type: LessonType.Videolesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 3,
@@ -171,7 +172,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Урок',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.Finished,
+          user_lesson_progress: UserLessonProgress.Finished,
         },
         {
           id: 4,
@@ -179,7 +180,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.Started,
+          user_lesson_progress: UserLessonProgress.InProgress,
         },
         {
           id: 5,
@@ -187,7 +188,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
       ],
     },
@@ -202,7 +203,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
       ],
     },
@@ -217,7 +218,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Дрессировка поисково-спасательных собак',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 2,
@@ -225,7 +226,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Видео',
           lesson_type: LessonType.Videolesson,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 3,
@@ -233,7 +234,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Урок',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 4,
@@ -241,7 +242,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 5,
@@ -249,7 +250,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
       ],
     },
@@ -264,7 +265,7 @@ const course: CourseModel = {
           duration: 1,
           title: 'Дрессировка поисково-спасательных собак',
           lesson_type: LessonType.Lesson,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 2,
@@ -272,7 +273,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Видео',
           lesson_type: LessonType.Videolesson,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 4,
@@ -280,7 +281,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 5,
@@ -288,7 +289,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
       ],
     },
@@ -303,7 +304,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Вебинар',
           lesson_type: LessonType.Webinar,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
         {
           id: 5,
@@ -311,7 +312,7 @@ const course: CourseModel = {
           duration: 2,
           title: 'Тест',
           lesson_type: LessonType.Quiz,
-          user_lesson_progress: LessonProgress.NotStarted,
+          user_lesson_progress: UserLessonProgress.NotStarted,
         },
       ],
     },

--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -1,15 +1,4 @@
-export enum LessonType {
-  Quiz = 'Quiz',
-  Videolesson = 'Videolesson',
-  Webinar = 'Webinar',
-  Lesson = 'Lesson',
-}
-
-export enum LessonProgress {
-  NotStarted = 0,
-  Started = 1,
-  Finished = 2,
-}
+import { LessonType, UserLessonProgress } from 'api/lessons';
 
 export enum UserProgressStatus {
   Enrolled = 'enrolled',
@@ -49,7 +38,7 @@ export type LessonChapterModel = {
   /** Тип урока. */
   lesson_type: LessonType;
   /** Статус прогресса урока. */
-  user_lesson_progress: LessonProgress;
+  user_lesson_progress: UserLessonProgress;
 };
 
 export type ChapterModel = {

--- a/src/api/lessons/index.ts
+++ b/src/api/lessons/index.ts
@@ -1,5 +1,4 @@
 export { lessonsApi } from './lessons.api';
-export { UserLessonProgress } from './types';
 export type {
   LessonModel,
   TestAnswerListModel,
@@ -10,3 +9,4 @@ export type {
   TestResultListModel,
   TestResultModel,
 } from './types';
+export { LessonType, UserLessonProgress } from './types';

--- a/src/api/lessons/mock/lesson.ts
+++ b/src/api/lessons/mock/lesson.ts
@@ -1,6 +1,5 @@
-import { LessonType } from 'api/course/types';
 import type { LessonModel } from '../types';
-import { UserLessonProgress } from '../types';
+import { LessonType, UserLessonProgress } from '../types';
 
 const lessons: Record<string, Record<string, LessonModel>> = {
   1: {

--- a/src/api/lessons/types.ts
+++ b/src/api/lessons/types.ts
@@ -1,5 +1,17 @@
-import type { LessonType } from 'api/course';
 import { Controls } from 'utils/constants';
+
+export enum LessonType {
+  Quiz = 'Quiz',
+  Videolesson = 'Videolesson',
+  Webinar = 'Webinar',
+  Lesson = 'Lesson',
+}
+
+export enum UserLessonProgress {
+  NotStarted,
+  InProgress,
+  Finished,
+}
 
 export type TestAnswerOptionsType =
   | Controls.RADIO
@@ -123,12 +135,6 @@ export type NextLessonModel = {
   chapter_id: Nullable<number>;
   lesson_id: Nullable<number>;
 };
-
-export enum UserLessonProgress {
-  NotStarted,
-  InProgress,
-  Finished,
-}
 
 export type LessonModel = {
   /** id урока */

--- a/src/components/organisms/contents-item/contents-item.tsx
+++ b/src/components/organisms/contents-item/contents-item.tsx
@@ -8,7 +8,7 @@ import { P } from 'components/atoms/typography';
 import { Accordion } from 'components/molecules/accordion';
 import { StyledLink } from 'components/molecules/styled-link';
 import { TextWithIcon } from 'components/molecules/text-with-icon';
-import { LessonProgress } from 'api/course';
+import { UserLessonProgress } from 'api/lessons';
 import styles from './contents-item.module.scss';
 import type { ContentsItemProps, LessonType } from './types';
 
@@ -27,7 +27,7 @@ function renderLesson(
 ) {
   const currentLessonRoute = `${routes.course.path}/${courseId}/${chapterId}/${lesson.id}`;
 
-  if (lesson.user_lesson_progress === LessonProgress.Finished) {
+  if (lesson.user_lesson_progress === UserLessonProgress.Finished) {
     return (
       <div
         className={classnames(styles.listItem, {
@@ -51,7 +51,7 @@ function renderLesson(
     );
   }
 
-  if (lesson.user_lesson_progress === LessonProgress.Started) {
+  if (lesson.user_lesson_progress === UserLessonProgress.InProgress) {
     return (
       <div
         className={classnames(styles.listItem, styles.active)}

--- a/src/components/organisms/error-locker/config.ts
+++ b/src/components/organisms/error-locker/config.ts
@@ -1,0 +1,9 @@
+import { ERROR_403 } from 'utils/constants';
+import type { ErrorLockerProps } from './types';
+
+export const forbiddenErrorPropsConfig: ErrorLockerProps = {
+  heading: ERROR_403,
+  subheading: 'Доступ запрещен',
+  content: 'У вас нет прав доступа к этой странице',
+  buttonText: 'Назад',
+};

--- a/src/components/organisms/error-locker/error-locker-content.tsx
+++ b/src/components/organisms/error-locker/error-locker-content.tsx
@@ -22,11 +22,13 @@ export const ErrorLockerContent: FC<ErrorLockerContentProps> = ({
     />
     {subheading && <P text={subheading} textAlign="center" />}
     {content && <P text={content} textAlign="center" />}
-    <Button
-      text={buttonText}
-      onClick={onClick}
-      view="secondary"
-      className={styles.button}
-    />
+    {onClick && (
+      <Button
+        text={buttonText}
+        onClick={onClick}
+        view="secondary"
+        className={styles.button}
+      />
+    )}
   </>
 );

--- a/src/components/organisms/error-locker/index.ts
+++ b/src/components/organisms/error-locker/index.ts
@@ -1,2 +1,3 @@
 export { ErrorLocker } from './error-locker';
 export type { ErrorLockerProps } from './types';
+export { forbiddenErrorPropsConfig } from './config';

--- a/src/components/organisms/error-locker/types.ts
+++ b/src/components/organisms/error-locker/types.ts
@@ -8,7 +8,7 @@ export type ErrorLockerContentProps = {
   /** Текст кнопки */
   buttonText?: string;
   /** Функция-обработчик клика */
-  onClick: VoidFunction;
+  onClick?: VoidFunction;
 };
 
 export type ErrorLockerProps = ErrorLockerContentProps & {

--- a/src/hooks/use-lesson.ts
+++ b/src/hooks/use-lesson.ts
@@ -29,7 +29,6 @@ type UseLesson = {
   fetchLesson: VoidFunction;
   goToPrevLesson: VoidFunction;
   goToNextLesson: VoidFunction;
-  completeCourse: VoidFunction;
 };
 
 /**
@@ -68,7 +67,7 @@ export const useLesson = (): UseLesson => {
 
     navigate(
       nextRoute ||
-        `${routes.course.path}/${lesson.course_id}/${chapterId}/${lessonId}/${SUBROUTES.complete}`
+        `${routes.course.path}/${lesson.course_id}/${SUBROUTES.complete}`
     );
   });
 
@@ -83,10 +82,6 @@ export const useLesson = (): UseLesson => {
     }
 
     navigateToNextLesson();
-  });
-
-  const completeCourse = useEvent(() => {
-    navigate(routes.courses.path);
   });
 
   useEffect(() => {
@@ -136,6 +131,5 @@ export const useLesson = (): UseLesson => {
     fetchLesson,
     goToPrevLesson,
     goToNextLesson,
-    completeCourse,
   };
 };

--- a/src/pages/complete-course/complete-course.tsx
+++ b/src/pages/complete-course/complete-course.tsx
@@ -1,75 +1,124 @@
-import { FC, useMemo } from 'react';
+import { FC, useEffect, useMemo } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { Card } from 'components/atoms/card';
 import { Loader } from 'components/molecules/loader';
 import { CourseContents } from 'components/organisms/course-contents';
 import { CourseCompleted } from 'components/organisms/course-completed';
 import { NavigationButtons } from 'components/organisms/navigation-buttons';
-import { ErrorLocker } from 'components/organisms/error-locker';
 import { BreadcrumbData, Breadcrumbs } from 'components/organisms/breadcrumbs';
+import {
+  ErrorLocker,
+  forbiddenErrorPropsConfig,
+} from 'components/organisms/error-locker';
 import { routes } from 'config';
 import { SUBROUTES } from 'router/routes';
-import { ProcessEnum } from 'utils/constants';
-import { useAppSelector } from 'store';
-import { selectCourse, selectCourseContents } from 'store/course/selectors';
-import { useLesson } from 'hooks/use-lesson';
+import { ErrorCodes } from 'api/core';
+import { UserProgressStatus } from 'api/course';
+import { LAST_INDEX, LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
+import { useAppDispatch, useAppSelector } from 'store';
+import {
+  selectCourse,
+  selectCourseContents,
+  selectCourseError,
+  selectCourseProcess,
+} from 'store/course/selectors';
+import { fetchCourseById } from 'store/course/thunk';
 import styles from './complete-course.module.scss';
 
-const courseCompletedTitle = routes.course.children?.complete.title ?? '';
+const TITLE = routes.course.children?.complete.title ?? '';
 
 const CompleteCourse: FC = () => {
-  const {
-    lesson,
-    lessonError,
-    lessonProcess,
-    isLoading,
-    fetchLesson,
-    goToPrevLesson,
-    completeCourse,
-  } = useLesson();
+  const { courseId = '' } = useParams();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   const course = useAppSelector(selectCourse);
+  const courseProcess = useAppSelector(selectCourseProcess);
+  const courseError = useAppSelector(selectCourseError);
   const contents = useAppSelector(selectCourseContents);
-  const isContentShown = lessonProcess === ProcessEnum.Succeeded;
 
-  const breadcrumbs: BreadcrumbData[] = useMemo(() => {
-    if (!lesson.id || !lesson.breadcrumbs) {
-      return [];
-    }
+  const isCourseCompleted =
+    course?.user_status === UserProgressStatus.Completed;
+  const isLoading = LOADING_PROCESS_MAP[courseProcess];
 
-    return [
+  const isForbiddenError =
+    courseError?.code === ErrorCodes.Forbidden || !isCourseCompleted;
+  const isError = courseError || isForbiddenError;
+
+  const isContentShown = !isError && courseProcess === ProcessEnum.Succeeded;
+
+  const breadcrumbs: BreadcrumbData[] = useMemo(
+    () => [
       {
         path: `${routes.courses.path}`,
         title: routes.courses.title,
       },
       {
-        path: `${routes.course.path}/${lesson.breadcrumbs.course.id}`,
-        title: lesson.breadcrumbs.course.title,
+        path: `${routes.course.path}/${course.id}`,
+        title: course.title,
       },
       {
-        path: `${lesson.breadcrumbs.chapter.id}/${lesson.id}/${SUBROUTES.complete}`,
-        title: courseCompletedTitle,
+        path: `${SUBROUTES.complete}`,
+        title: TITLE,
       },
-    ];
-  }, [lesson.id, lesson.breadcrumbs]);
+    ],
+    [course.id, course.title]
+  );
+
+  const fetchCourse = () => {
+    if (courseId) {
+      void dispatch(fetchCourseById(courseId));
+    }
+  };
+
+  const handleForbiddenError = () => navigate(LAST_INDEX);
+
+  const goToPrevLesson = () => {
+    const lastChapter = contents.at(LAST_INDEX);
+    const lastLesson = lastChapter?.lessons.at(LAST_INDEX);
+    const coursePageRoute = `${routes.course.path}/${course.id}`;
+
+    const route =
+      lastChapter && lastLesson
+        ? `${coursePageRoute}/${lastChapter.id}/${lastLesson.id}`
+        : coursePageRoute;
+
+    navigate(route);
+  };
+
+  const completeCourse = () => {
+    navigate(routes.courses.path);
+  };
+
+  useEffect(() => {
+    fetchCourse();
+  }, [courseId]);
+
+  if (courseError?.code === ErrorCodes.NotFound) {
+    return <Navigate to={routes.notFound.path} replace />;
+  }
 
   return (
     <>
-      {lesson.breadcrumbs && (
-        <Breadcrumbs className={styles.breadcrumbs} breadcrumbs={breadcrumbs} />
-      )}
+      <Breadcrumbs className={styles.breadcrumbs} breadcrumbs={breadcrumbs} />
 
       <div className={styles.wrapper}>
-        {(isLoading || lessonError) && (
+        {(isLoading || isError) && (
           <Card className={styles.error} htmlTag="section">
             {isLoading && <Loader />}
-            {lessonError && <ErrorLocker onClick={fetchLesson} />}
+            {isError && (
+              <ErrorLocker
+                {...(isForbiddenError && forbiddenErrorPropsConfig)}
+                onClick={isForbiddenError ? handleForbiddenError : fetchCourse}
+              />
+            )}
           </Card>
         )}
 
         {isContentShown && (
           <div className={styles.content}>
             <CourseCompleted
-              title={courseCompletedTitle}
+              title={TITLE}
               courseTitle={course.title}
               href={routes.courses.path}
               isCompleted

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -11,12 +11,14 @@ import { NavigationButtons } from 'components/organisms/navigation-buttons';
 import { PreviewWebinar } from 'components/organisms/preview-webinar';
 import { VideoLesson } from 'components/organisms/video-lesson';
 import { TestContent } from 'components/organisms/test-content';
-import { ErrorLocker } from 'components/organisms/error-locker';
+import {
+  ErrorLocker,
+  forbiddenErrorPropsConfig,
+} from 'components/organisms/error-locker';
 import { routes } from 'config';
 import { ErrorCodes } from 'api/core';
-import { LessonType } from 'api/course';
-import { UserLessonProgress } from 'api/lessons';
-import { ERROR_403, LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
+import { LessonType, UserLessonProgress } from 'api/lessons';
+import { LAST_INDEX, LOADING_PROCESS_MAP, ProcessEnum } from 'utils/constants';
 import { useAppSelector } from 'store';
 import { selectCourseContents } from 'store/course/selectors';
 import {
@@ -55,6 +57,7 @@ const Lesson: FC = () => {
   const isWebinar = lessonType === LessonType.Webinar;
   const isLesson = lessonType === LessonType.Lesson;
   const isContentShown = lessonProcess === ProcessEnum.Succeeded;
+  const isForbiddenError = lessonError?.code === ErrorCodes.Forbidden;
 
   const videoId = lesson.video_link && getYouTubeID(lesson.video_link);
 
@@ -103,6 +106,8 @@ const Lesson: FC = () => {
   const isNextButtonDisabled =
     isNotStarted || isLoadingProcess || isQuizDisabledCondition;
 
+  const handleForbiddenError = () => navigate(LAST_INDEX);
+
   if (lessonError?.code === ErrorCodes.NotFound) {
     return <Navigate to={routes.notFound.path} replace />;
   }
@@ -117,18 +122,12 @@ const Lesson: FC = () => {
         {(isLoading || lessonError) && (
           <Card className={styles.error} htmlTag="section">
             {isLoading && <Loader />}
-            {lessonError &&
-              (lessonError.code === ErrorCodes.Forbidden ? (
-                <ErrorLocker
-                  onClick={() => navigate(-1)}
-                  heading={ERROR_403}
-                  subheading="Доступ запрещен"
-                  content="У вас нет прав доступа к этой странице"
-                  buttonText="Назад"
-                />
-              ) : (
-                <ErrorLocker onClick={fetchLesson} />
-              ))}
+            {lessonError && (
+              <ErrorLocker
+                {...(isForbiddenError && forbiddenErrorPropsConfig)}
+                onClick={isForbiddenError ? handleForbiddenError : fetchLesson}
+              />
+            )}
           </Card>
         )}
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -29,7 +29,7 @@ export const defaultRoutes: Record<string, RouteType> = {
       },
       complete: {
         title: 'Курс завершен',
-        path: `${SUBROUTES.courseId}/${SUBROUTES.chapterId}/${SUBROUTES.lessonId}/${SUBROUTES.complete}`,
+        path: `${SUBROUTES.courseId}/${SUBROUTES.complete}`,
       },
     },
   },

--- a/src/store/lesson/slice.ts
+++ b/src/store/lesson/slice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { ProcessEnum } from 'utils/constants';
-import { LessonType } from 'api/course';
+import { LessonType } from 'api/lessons';
 import { completeLesson, fetchLessonById } from './thunk';
 import type { LessonState } from './types';
 

--- a/src/styles/lesson-page.scss
+++ b/src/styles/lesson-page.scss
@@ -26,4 +26,5 @@
 
 @mixin error {
   width: 100%;
+  min-height: 164px;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,7 @@ import { UserProgressStatus } from 'api/course';
 
 export const SPINNER_DELAY = 300;
 export const DELAY_DEBOUNCE = 300;
+export const LAST_INDEX = -1;
 
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_SIZE = 10;


### PR DESCRIPTION
## Связанная задача: [Если в адресной строке дописать в конце URL "/comlete" при прохождении урока и нажать Enter, то проиcходит переброс на страницу завершений курса](https://linear.app/lizaalert/issue/MIL-82/esli-v-adresnoj-stroke-dopisat-v-konce-url-comlete-pri-prohozhdenii)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- Переработана страница завершения курса: отвязана от урока, url сокращен до `/course/{id}/complete`
- Если статус курса `completed` (ставится бэком при завершении последней главы до перехода на страницу завершения курса), то показывается плашка о завершении курса, иначе 403 ошибка (нет доступа)
- Если бэк возвращает 403, 404 или 500, то показывается соответствующая ошибка
- Удален дублирующий `UserLessonProgress` enum `LessonProgress`
- enum `LessonType` перенесен в `api/lessons/types.ts`
- Для 403 ошибки добавлен конфиг пропов для `ErrorLocker`, компонент обновлен на странице урока
