### PR TITLE
MIL-97: дата начала курса берется из ответа ручки enroll

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -4,5 +4,6 @@ export type {
   ChapterModel,
   LessonChapterModel,
   CurrentLessonModel,
+  EnrollModel,
 } from './types';
 export { UserProgressStatus } from './types';

--- a/src/api/course/mock/enroll.ts
+++ b/src/api/course/mock/enroll.ts
@@ -2,6 +2,7 @@ import { type EnrollModel, UserProgressStatus } from 'api/course/types';
 
 const enrollResponse: EnrollModel = {
   user_status: UserProgressStatus.Available,
+  start_date: '2024-02-01',
 };
 
 export default Promise.resolve(() => enrollResponse);

--- a/src/api/course/types.ts
+++ b/src/api/course/types.ts
@@ -69,7 +69,7 @@ export type CourseModel = {
   /** Список навыков, получаемых на курсе */
   knowledge: KnowledgeModel[];
   /** Дата начала прохождения курса. */
-  start_date: string;
+  start_date: Nullable<string>;
   /** URL к обложке курса. */
   cover_path: Nullable<string>;
   /** Количество уроков в курсе. */
@@ -84,4 +84,5 @@ export type CourseModel = {
 
 export type EnrollModel = {
   user_status: UserProgressStatus;
+  start_date: string;
 };

--- a/src/api/courses/types.ts
+++ b/src/api/courses/types.ts
@@ -12,13 +12,13 @@ export type CoursePreviewModel = {
   /** Количество уроков в курсе. */
   lessons_count: number;
   /** Дата начала курса. */
-  start_date: string;
+  start_date: Nullable<string>;
   /** Продолжительность курса в часах. */
   course_duration: Nullable<number>;
   /** Статус курса. */
   course_status: 'active' | 'inactive' | 'finished' | 'booked';
   /** URL к обложке курса. */
-  cover_path: string | null;
+  cover_path: Nullable<string>;
   /** Статус подписки пользователя на курс. */
   user_status?: UserProgressStatus;
 };
@@ -34,7 +34,7 @@ export type GetCoursesData = {
 
 export type CoursesModel = {
   /** Общее количество курсов в базе данных. */
-  count: number | null;
+  count: Nullable<number>;
   /** Список курсов. */
   results: CoursePreviewModel[];
 };

--- a/src/components/organisms/course-overview/course-overview.tsx
+++ b/src/components/organisms/course-overview/course-overview.tsx
@@ -28,6 +28,7 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
 }) => {
   const {
     buttonText,
+    currentStartDate,
     isEnrolled,
     isButtonDisabled,
     handleEnroll,
@@ -68,10 +69,12 @@ export const CourseOverview: FC<CourseOverviewProps> = ({
           </Li>
         )}
 
-        <Li className={styles.courseMetaItem}>
-          <TextWithIcon text="Старт занятий:" iconType="calendar" />
-          {convertDate(startDate)} г
-        </Li>
+        {currentStartDate && (
+          <Li className={styles.courseMetaItem}>
+            <TextWithIcon text="Старт занятий:" iconType="calendar" />
+            {convertDate(currentStartDate)} г
+          </Li>
+        )}
       </ul>
 
       <TextWithIcon

--- a/src/components/organisms/course-overview/types.ts
+++ b/src/components/organisms/course-overview/types.ts
@@ -7,7 +7,7 @@ export type CourseOverviewProps = {
   /** Уровень (квалификация) курса. */
   level: string;
   /** Дата начала занятий. */
-  startDate: string;
+  startDate: Nullable<string>;
   /** URL обложки курса. */
   coverPath?: Nullable<string>;
   /** Количество уроков в курсе. */

--- a/src/components/organisms/with-infinite-scroll/types.ts
+++ b/src/components/organisms/with-infinite-scroll/types.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { ProcessEnum } from 'utils/constants';
+import { SerializedError } from 'api/core';
 
 type BasePaginationState = {
   /** Следующая подгружаемая страница. */
@@ -29,7 +30,7 @@ export type WithInfiniteScrollConfig<T, State> = {
   /** Общее количество элементов, которое будет отображено. */
   total: number;
   /** Ошибка, которая может возникнуть при загрузке ленты. При ошибке прекращаются все дальнейшие запросы. */
-  error?: string | null;
+  error?: Nullable<SerializedError>;
   /** Процесс выполнения запроса. */
   process: ProcessEnum;
   /** То, что нужно отобразить из родителя. */

--- a/src/hooks/use-enroll-course.ts
+++ b/src/hooks/use-enroll-course.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { routes } from 'config';
-import { CourseStatusButtons, ProcessEnum } from 'utils/constants';
 import { UserProgressStatus } from 'api/course';
+import { CourseStatusButtons, ProcessEnum } from 'utils/constants';
+import { convertDate } from 'utils/convert-date';
 import { useAppDispatch, useAppSelector } from 'store';
 import { selectIsAuth } from 'store/auth/selectors';
 import {
@@ -18,7 +19,7 @@ type UseEnrollCourseConfig = {
   /** Статус подписки на курс как есть */
   userStatus: UserProgressStatus;
   /** Дата начала курса. */
-  startDate: string;
+  startDate: Nullable<string>;
   /** Изменяемые данные статуса подписки на курс из стора */
   enrollStatus?: EnrollStatusType;
 };
@@ -27,6 +28,7 @@ type UseEnrollCourse = {
   isEnrolled: boolean;
   isButtonDisabled: boolean;
   buttonText: string;
+  currentStartDate: Nullable<string>;
   handleEnroll: VoidFunction;
   handleUnroll: VoidFunction;
 };
@@ -43,6 +45,7 @@ export const useEnrollCourse = ({
   const isAuth = useAppSelector(selectIsAuth);
   const currentUserStatus = enrollStatus?.userStatus || userStatus;
   const currentLesson = enrollStatus?.currentLesson;
+  const currentStartDate = enrollStatus?.startDate ?? startDate;
 
   const isEnrolled = currentUserStatus !== UserProgressStatus.NotEnrolled;
   const canStudy = currentUserStatus !== UserProgressStatus.Enrolled;
@@ -52,10 +55,10 @@ export const useEnrollCourse = ({
     currentLesson?.process === ProcessEnum.Requested;
 
   const buttonText = useMemo(() => {
-    const localStartDate = new Date(startDate).toLocaleDateString('ru-RU', {
-      day: 'numeric',
-      month: 'short',
+    const localStartDate = convertDate(currentStartDate, {
+      withShortMonth: true,
     });
+
     return currentUserStatus === UserProgressStatus.Enrolled
       ? `Начнется ${localStartDate || 'скоро'}`
       : CourseStatusButtons[currentUserStatus];
@@ -98,6 +101,7 @@ export const useEnrollCourse = ({
     isEnrolled,
     isButtonDisabled,
     buttonText,
+    currentStartDate,
     handleEnroll,
     handleUnroll,
   };

--- a/src/store/course/slice.ts
+++ b/src/store/course/slice.ts
@@ -16,7 +16,7 @@ const initialState: CourseState = {
     full_description: '',
     faq: [],
     knowledge: [],
-    start_date: '',
+    start_date: null,
     cover_path: null,
     lessons_count: 0,
     course_duration: 0,

--- a/src/store/courses/slice.ts
+++ b/src/store/courses/slice.ts
@@ -51,17 +51,19 @@ export const coursesSlice = createSlice({
         process: ProcessEnum.Requested,
         error: null,
         userStatus: UserProgressStatus.NotEnrolled,
+        startDate: null,
       };
     });
     builder.addCase(
       enrollCourseById.fulfilled,
       (state, { meta: { arg }, payload }) => {
-        const { user_status: userStatus } = payload;
+        const { user_status: userStatus, start_date: startDate } = payload;
         state.enrollStatus[arg] = {
           ...state.enrollStatus[arg],
           process: ProcessEnum.Succeeded,
           error: null,
           userStatus,
+          startDate,
         };
       }
     );
@@ -73,6 +75,7 @@ export const coursesSlice = createSlice({
           process: ProcessEnum.Failed,
           error,
           userStatus: UserProgressStatus.NotEnrolled,
+          startDate: null,
         };
       }
     );

--- a/src/store/courses/types.ts
+++ b/src/store/courses/types.ts
@@ -1,12 +1,17 @@
 import { SerializedError } from 'api/core';
 import type { CoursesModel } from 'api/courses';
-import type { CurrentLessonModel, UserProgressStatus } from 'api/course';
+import type {
+  CurrentLessonModel,
+  EnrollModel,
+  UserProgressStatus,
+} from 'api/course';
 import { ProcessEnum } from 'utils/constants';
 
 export type EnrollStatusType = {
   process: ProcessEnum;
   error: Nullable<SerializedError>;
   userStatus: UserProgressStatus;
+  startDate: Nullable<EnrollModel['start_date']>;
   currentLesson?: {
     process: ProcessEnum;
     error: Nullable<SerializedError>;

--- a/src/utils/convert-date.ts
+++ b/src/utils/convert-date.ts
@@ -1,17 +1,22 @@
 type Options = {
   onlyTime?: boolean;
   isDateTime?: boolean;
+  withShortMonth?: boolean;
   locales?: string;
 };
 
 export const convertDate = (
-  date: string,
+  date?: Nullable<string>,
   options: Options = {
     isDateTime: false,
     onlyTime: false,
     locales: 'ru-RU',
   }
 ): string => {
+  if (!date) {
+    return '';
+  }
+
   if (options.onlyTime) {
     return new Date(date).toLocaleTimeString(options.locales, {
       hour: '2-digit',
@@ -23,6 +28,13 @@ export const convertDate = (
     return new Date(date).toLocaleDateString(options.locales, {
       hour: '2-digit',
       minute: '2-digit',
+    });
+  }
+
+  if (options.withShortMonth) {
+    return new Date(date).toLocaleDateString(options.locales, {
+      day: 'numeric',
+      month: 'short',
     });
   }
 


### PR DESCRIPTION
## Связанная задача: [При записи на курс и нажатии кнопки Записаться на курс с отложенной датой начала, кнопка меняется на "Начнется 1 янв" дата не соответсвует дате начала курса](https://linear.app/lizaalert/issue/MIL-97/pri-zapisi-na-kurs-i-nazhatii-knopki-zapisatsya-na-kurs-s-otlozhennoj)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- Дата начала курса берется из ответа ручки `enroll`
- Строка с датой начала в карточке курса не отображается, если нет даты
