### PR TITLE
MIL-91: Поддержать вкладки "Посмотреть условия" и "Вернуться к тесту"

### DIFF
--- a/src/components/molecules/test-answer/test-answer.tsx
+++ b/src/components/molecules/test-answer/test-answer.tsx
@@ -14,6 +14,7 @@ export const TestAnswer: FC<TestAnswerProps> = ({
   content,
   questionId,
   answerOptions,
+  isSelected = false,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -32,6 +33,7 @@ export const TestAnswer: FC<TestAnswerProps> = ({
       value={content.text}
       labelText={content.text}
       onChange={updateCheckStatus}
+      checked={isSelected}
     />
   );
 };

--- a/src/components/molecules/test-answer/types.ts
+++ b/src/components/molecules/test-answer/types.ts
@@ -19,4 +19,6 @@ export type TestAnswerProps = {
   questionId: number;
   /** Тип чекбокса: мультивыбор или радио. */
   answerOptions: TestAnswerOptionsType;
+  /** Флаг, определяющий выбран ли ответ. */
+  isSelected?: boolean;
 };

--- a/src/components/organisms/test-question/test-question.tsx
+++ b/src/components/organisms/test-question/test-question.tsx
@@ -3,8 +3,6 @@ import classnames from 'classnames';
 import { Heading } from 'components/atoms/typography';
 import { TestAnswer } from 'components/molecules/test-answer';
 import { TestResults } from 'components/molecules/test-results';
-import { useAppSelector } from 'store';
-import { selectTestResult } from 'store/test/selectors';
 import styles from './test-question.module.scss';
 import type { TestQuestionProps } from './types';
 
@@ -17,10 +15,9 @@ export const TestQuestion: FC<TestQuestionProps> = ({
   index,
   type,
   isSubmitted = false,
+  validatedAnswers,
   className = '',
 }) => {
-  const testResult = useAppSelector(selectTestResult);
-
   // список ответов
   const answersList = question.content.map((answer) => (
     <li key={answer.id}>
@@ -31,11 +28,6 @@ export const TestQuestion: FC<TestQuestionProps> = ({
       />
     </li>
   ));
-
-  const currentQuestionResult = testResult.find(
-    (result) => result.questionId === question.id
-  );
-  const validatedAnswers = currentQuestionResult?.validatedAnswers || {};
 
   // список с проверкой ответов теста
   const resultsList = question.content.map((answer) => (

--- a/src/components/organisms/test-question/test-question.tsx
+++ b/src/components/organisms/test-question/test-question.tsx
@@ -25,6 +25,7 @@ export const TestQuestion: FC<TestQuestionProps> = ({
         content={answer}
         questionId={question.id}
         answerOptions={type}
+        isSelected={answer.selected}
       />
     </li>
   ));

--- a/src/components/organisms/test-question/types.ts
+++ b/src/components/organisms/test-question/types.ts
@@ -1,5 +1,6 @@
 import type { TestQuestionModel } from 'api/lessons';
 import type { TestAnswerOptionsType } from 'components/molecules/test-answer';
+import type { TestResultRecord } from 'components/molecules/test-results';
 
 export type TestQuestionProps = {
   /** Объект вопроса, содержит id, title, question_type и content (массив ответов). */
@@ -10,6 +11,8 @@ export type TestQuestionProps = {
   type: TestAnswerOptionsType;
   /** Флаг отправки ответа. */
   isSubmitted?: boolean;
+  /** Мапа провалидированных ответов теста */
+  validatedAnswers: TestResultRecord;
   /** Миксин для стилизации. Используйте css-класс, чтобы изменить css-свойства элемента. */
   className?: string;
 };

--- a/src/components/organisms/test/hooks/use-test.ts
+++ b/src/components/organisms/test/hooks/use-test.ts
@@ -55,9 +55,9 @@ export const useTest = () => {
   const handleRetryTest = () => {
     if (lessonId) {
       void dispatch(createTest(lessonId));
+      dispatch(updateAnswerReset());
+      dispatch(resetTestResult());
     }
-    dispatch(updateAnswerReset());
-    dispatch(resetTestResult());
   };
 
   const sendTestOnValidation = async (): Promise<void> => {

--- a/src/components/organisms/test/hooks/use-test.ts
+++ b/src/components/organisms/test/hooks/use-test.ts
@@ -9,6 +9,7 @@ import {
   selectTest,
   selectTestPassingScore,
   selectTestProcess,
+  selectTestResult,
   selectTestResultPercent,
 } from 'store/test/selectors';
 import { resetTestResult, updateAnswerReset } from 'store/test/slice';
@@ -29,6 +30,7 @@ export const useTest = () => {
   const testProcess = useAppSelector(selectTestProcess);
   const testCreationProcess = useAppSelector(selectProcessCreationTest);
   const testValidationProcess = useAppSelector(selectProcessValidationTest);
+  const testResult = useAppSelector(selectTestResult);
   const testResultPercent = useAppSelector(selectTestResultPercent);
   const testPassingScore = useAppSelector(selectTestPassingScore);
   const isSuccess =
@@ -86,5 +88,6 @@ export const useTest = () => {
     handleSubmitTest,
     handleRetryTest,
     testResultPercent,
+    testResult,
   };
 };

--- a/src/components/organisms/test/test.tsx
+++ b/src/components/organisms/test/test.tsx
@@ -6,7 +6,7 @@ import { TestSuccessRate } from 'components/molecules/test-success-rate';
 import { TestQuestion } from 'components/organisms/test-question';
 import { useTest } from './hooks/use-test';
 import styles from './test.module.scss';
-import type { RenderQuestionsListArgs, TestProps } from './types';
+import type { TestProps } from './types';
 
 /**
  * Компонент-карточка теста с вопросами.
@@ -44,11 +44,17 @@ export const Test: FC<TestProps> = ({ onShowPreview }) => {
 
       <form onSubmit={handleSubmitTest} name="testForm" className={styles.form}>
         <ul className={styles.list}>
-          {renderQuestionsList({
-            questions: test.questions,
-            testResult,
-            isSubmitted: isTestValidationSucceeded,
-          })}
+          {test.questions.map((question, index) => (
+            <li className={styles.listItem} key={question.id}>
+              <TestQuestion
+                question={question}
+                type={question.question_type}
+                index={index}
+                isSubmitted={isTestValidationSucceeded}
+                validatedAnswers={testResult[question.id]}
+              />
+            </li>
+          ))}
         </ul>
 
         {isTestValidationSucceeded && (
@@ -79,22 +85,3 @@ export const Test: FC<TestProps> = ({ onShowPreview }) => {
     </Card>
   );
 };
-
-/** Отрисовка списка вопросов */
-function renderQuestionsList({
-  questions,
-  testResult,
-  isSubmitted,
-}: RenderQuestionsListArgs) {
-  return questions.map((question, index) => (
-    <li className={styles.listItem} key={question.id}>
-      <TestQuestion
-        question={question}
-        type={question.question_type}
-        index={index}
-        isSubmitted={isSubmitted}
-        validatedAnswers={testResult[question.id]}
-      />
-    </li>
-  ));
-}

--- a/src/components/organisms/test/test.tsx
+++ b/src/components/organisms/test/test.tsx
@@ -4,10 +4,9 @@ import { Heading } from 'components/atoms/typography';
 import { Button } from 'components/molecules/button';
 import { TestSuccessRate } from 'components/molecules/test-success-rate';
 import { TestQuestion } from 'components/organisms/test-question';
-import type { TestQuestionModel } from 'api/lessons';
 import { useTest } from './hooks/use-test';
 import styles from './test.module.scss';
-import type { TestProps } from './types';
+import type { RenderQuestionsListArgs, TestProps } from './types';
 
 /**
  * Компонент-карточка теста с вопросами.
@@ -19,6 +18,7 @@ export const Test: FC<TestProps> = ({ onShowPreview }) => {
     isTestValidationSucceeded,
     isSubmitButtonDisabled,
     testResultPercent,
+    testResult,
     test,
     handleSubmitTest,
     handleRetryTest,
@@ -44,7 +44,11 @@ export const Test: FC<TestProps> = ({ onShowPreview }) => {
 
       <form onSubmit={handleSubmitTest} name="testForm" className={styles.form}>
         <ul className={styles.list}>
-          {renderQuestionsList(test.questions, isTestValidationSucceeded)}
+          {renderQuestionsList({
+            questions: test.questions,
+            testResult,
+            isSubmitted: isTestValidationSucceeded,
+          })}
         </ul>
 
         {isTestValidationSucceeded && (
@@ -77,10 +81,11 @@ export const Test: FC<TestProps> = ({ onShowPreview }) => {
 };
 
 /** Отрисовка списка вопросов */
-function renderQuestionsList(
-  questions: TestQuestionModel[],
-  isSubmitted: boolean
-) {
+function renderQuestionsList({
+  questions,
+  testResult,
+  isSubmitted,
+}: RenderQuestionsListArgs) {
   return questions.map((question, index) => (
     <li className={styles.listItem} key={question.id}>
       <TestQuestion
@@ -88,6 +93,7 @@ function renderQuestionsList(
         type={question.question_type}
         index={index}
         isSubmitted={isSubmitted}
+        validatedAnswers={testResult[question.id]}
       />
     </li>
   ));

--- a/src/components/organisms/test/types.ts
+++ b/src/components/organisms/test/types.ts
@@ -1,6 +1,4 @@
 import type { TestResultRecord } from 'components/molecules/test-results';
-import type { TestQuestionModel } from 'api/lessons';
-import type { TestValidatedMapType } from 'utils/validate-answers';
 
 export type TestProps = {
   /** Функция возврата к превью теста. */
@@ -15,10 +13,4 @@ export type TestAnswerType = {
 export type TestValidatedType = {
   questionId: number;
   validatedAnswers: TestResultRecord;
-};
-
-export type RenderQuestionsListArgs = {
-  questions: TestQuestionModel[];
-  testResult: TestValidatedMapType;
-  isSubmitted: boolean;
 };

--- a/src/components/organisms/test/types.ts
+++ b/src/components/organisms/test/types.ts
@@ -1,4 +1,6 @@
 import type { TestResultRecord } from 'components/molecules/test-results';
+import type { TestQuestionModel } from 'api/lessons';
+import type { TestValidatedMapType } from 'utils/validate-answers';
 
 export type TestProps = {
   /** Функция возврата к превью теста. */
@@ -13,4 +15,10 @@ export type TestAnswerType = {
 export type TestValidatedType = {
   questionId: number;
   validatedAnswers: TestResultRecord;
+};
+
+export type RenderQuestionsListArgs = {
+  questions: TestQuestionModel[];
+  testResult: TestValidatedMapType;
+  isSubmitted: boolean;
 };

--- a/src/pages/lesson/lesson.tsx
+++ b/src/pages/lesson/lesson.tsx
@@ -27,8 +27,8 @@ import {
   selectLessonType,
 } from 'store/lesson/selectors';
 import {
+  selectProcessValidationTest,
   selectTestPassingScore,
-  selectTestResult,
   selectTestResultPercent,
 } from 'store/test/selectors';
 import { useLesson } from 'hooks/use-lesson';
@@ -49,9 +49,9 @@ const Lesson: FC = () => {
   const contents = useAppSelector(selectCourseContents);
   const lessonType = useAppSelector(selectLessonType);
   const completeLessonProcess = useAppSelector(selectCompleteLessonProcess);
-  const quizResultData = useAppSelector(selectTestResult);
   const quizResultPercent = useAppSelector(selectTestResultPercent);
   const quizPassingScore = useAppSelector(selectTestPassingScore);
+  const processValidationTest = useAppSelector(selectProcessValidationTest);
 
   const isQuiz = lessonType === LessonType.Quiz;
   const isVideolesson = lessonType === LessonType.Videolesson;
@@ -102,7 +102,8 @@ const Lesson: FC = () => {
     typeof quizPassingScore === 'number' &&
     quizResultPercent < quizPassingScore;
 
-  const isQuizNotCompleted = !quizResultData.length || hasValidQuizPassingScore;
+  const isQuizNotCompleted =
+    processValidationTest !== ProcessEnum.Succeeded || hasValidQuizPassingScore;
   const isQuizDisabledCondition = isQuiz && isInProgress && isQuizNotCompleted;
 
   const isNextButtonDisabled =

--- a/src/store/test/slice.ts
+++ b/src/store/test/slice.ts
@@ -23,7 +23,7 @@ const initialState: TestState = {
     questions: [],
   },
   answersOnValidate: [],
-  testResult: [],
+  testResult: {},
   process: ProcessEnum.Initial,
   processValidationTest: ProcessEnum.Initial,
   processCreationTest: ProcessEnum.Initial,

--- a/src/store/test/slice.ts
+++ b/src/store/test/slice.ts
@@ -36,27 +36,34 @@ export const testSlice = createSlice({
   initialState,
   reducers: {
     updateAnswer: (state, action: UpdateAnswerAction) => {
-      if (state.processCreationTest && state.test && state.test.questions) {
+      if (
+        state.processCreationTest === ProcessEnum.Succeeded &&
+        state.test.questions
+      ) {
         state.test.questions = state.test.questions.map((question) => {
-          if (question.id === action.payload?.questionId) {
-            return {
-              ...question,
-              content: question.content.map((answer) => {
-                if (answer.id === action.payload?.answerId) {
-                  return {
-                    ...answer,
-                    selected: !answer.selected,
-                  };
-                }
-                if (question.question_type === Controls.RADIO) {
-                  return { ...answer, selected: false };
-                }
-                return answer;
-              }),
-            };
+          if (question.id !== action.payload?.questionId) {
+            return question;
           }
-          return question;
+
+          return {
+            ...question,
+            content: question.content.map((answer) => {
+              if (answer.id === action.payload?.answerId) {
+                return {
+                  ...answer,
+                  selected: !answer.selected,
+                };
+              }
+
+              if (question.question_type === Controls.RADIO) {
+                return { ...answer, selected: false };
+              }
+
+              return answer;
+            }),
+          };
         });
+
         state.answersOnValidate = state.test.questions.map((question) => ({
           question_id: question.id,
           answer_id: question.content
@@ -66,7 +73,7 @@ export const testSlice = createSlice({
       }
     },
     updateAnswerReset: (state) => {
-      if (state.processCreationTest && state.test && state.test.questions) {
+      if (state.test.questions) {
         state.test.questions = state.test.questions.map((question) => ({
           ...question,
           content: question.content.map((answer) => ({
@@ -100,6 +107,7 @@ export const testSlice = createSlice({
           : [],
       };
     });
+
     builder.addCase(validateTest.pending, (state) => {
       state.processValidationTest = ProcessEnum.Requested;
       state.error = null;

--- a/src/store/test/types.ts
+++ b/src/store/test/types.ts
@@ -1,12 +1,12 @@
 import { SerializedError } from 'api/core';
 import { ProcessEnum } from 'utils/constants';
 import type { TestModel, TestOnValidationData } from 'api/lessons';
-import type { TestValidatedType } from 'components/organisms/test';
+import type { TestValidatedMapType } from 'utils/validate-answers';
 
 export type TestState = {
   test: TestModel;
   answersOnValidate: TestOnValidationData[];
-  testResult: TestValidatedType[];
+  testResult: TestValidatedMapType;
   testResultPercent: Nullable<number>;
   error: Nullable<SerializedError>;
   process: ProcessEnum;

--- a/src/utils/validate-answers.ts
+++ b/src/utils/validate-answers.ts
@@ -1,40 +1,42 @@
-import type {
-  TestAnswerType,
-  TestValidatedType,
-} from 'components/organisms/test';
+import type { TestAnswerType } from 'components/organisms/test';
 import type { TestResultRecord } from 'components/molecules/test-results';
-import { TestAnswerStatus } from './constants';
+import { TestAnswerStatus } from 'utils/constants';
+
+export type TestValidatedMapType = Record<string, TestResultRecord>;
 
 export const validateAnswers = (
   correctAnswersList: { questionId: number; correctAnswers: number[] }[],
   userAnswersList: TestAnswerType[]
-): TestValidatedType[] =>
-  correctAnswersList.map(({ questionId, correctAnswers }) => {
-    const userAnswer = userAnswersList.find(
-      (user) => user.questionId === questionId
-    );
+): TestValidatedMapType =>
+  correctAnswersList.reduce<TestValidatedMapType>(
+    (memo, { questionId, correctAnswers }) => {
+      const userAnswer = userAnswersList.find(
+        (user) => user.questionId === questionId
+      );
 
-    const correctSet = new Set(correctAnswers);
-    const userAnswerSet = new Set(userAnswer?.answerId || []);
+      const correctSet = new Set(correctAnswers);
+      const userAnswerSet = new Set(userAnswer?.answerId || []);
 
-    const result: TestResultRecord = {};
+      const result: TestResultRecord = {};
 
-    correctSet.forEach((answerId) => {
-      if (userAnswerSet.has(answerId)) {
-        result[answerId] = TestAnswerStatus.Correct;
-      } else {
-        result[answerId] = TestAnswerStatus.Unanswered;
-      }
-    });
+      correctSet.forEach((answerId) => {
+        if (userAnswerSet.has(answerId)) {
+          result[answerId] = TestAnswerStatus.Correct;
+        } else {
+          result[answerId] = TestAnswerStatus.Unanswered;
+        }
+      });
 
-    userAnswerSet.forEach((answerId) => {
-      if (!(answerId in result)) {
-        result[answerId] = TestAnswerStatus.Incorrect;
-      }
-    });
+      userAnswerSet.forEach((answerId) => {
+        if (!(answerId in result)) {
+          result[answerId] = TestAnswerStatus.Incorrect;
+        }
+      });
 
-    return {
-      questionId,
-      validatedAnswers: result,
-    };
-  });
+      return {
+        ...memo,
+        [questionId]: result,
+      };
+    },
+    {}
+  );


### PR DESCRIPTION
## Связанная задача: [Поддержать вкладки "Посмотреть условия" и "Вернуться к тесту"](https://linear.app/lizaalert/issue/MIL-91/podderzhat-vkladki-posmotret-usloviya-i-vernutsya-k-testu)

### [Стайлгайд](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/blob/master/docs/style-guide.md)

### Описание выполненной работы:

- утилка `validateAnswers` теперь возвращает объект, а не массив, чтобы передавать в `TestQuestion` только его данные по айдишнику и не искать их по всему массиву в каждом компоненте
- при переключении вкладок "Посмотреть условия" и "Вернуться к тесту" выбранные ответы не сбрасываются

![Peek 2024-03-04 15-25](https://github.com/Studio-Yandex-Practicum/lizaalert_frontend/assets/75016726/c703e622-20a3-49be-8375-941fb44505ba)

